### PR TITLE
docs: explain the two connected Vercel projects and the red check

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,3 +171,20 @@ Hosted on **Vercel** (`focess-five.vercel.app`). All static assets are served
 from the Vercel edge CDN same-origin; the service worker precaches them. An
 external CDN is intentionally **not** used — it would add cross-origin
 connection cost without benefit.
+
+> **Two Vercel projects are connected to this repo — only one is real.**
+>
+> - **`focces`** (under `sebins-projects-41e1f03e`) is the **canonical
+>   project**: it owns the production domain `focess-five.vercel.app` and
+>   deploys successfully on every push/PR. This is the one that matters.
+> - **`official-website-v3`** (under the `foces-cecs-projects` team) is a
+>   leftover from the early "fix(vercel)" era. It has **failed every
+>   deployment since the repo first connected to Vercel (Aug 5, 2026)** —
+>   same commits deploy fine on `focces`, so the breakage is in that
+>   project's Vercel-side settings, not in this codebase.
+>
+> Consequence: every PR shows a red **"Vercel – official-website-v3"** check.
+> It is cosmetic — that project is not the deploy path and never gates
+> merges. The clean fix is Vercel dashboard → that project → **Settings →
+> Git → Disconnect GitHub repo** (needs an account with access to the
+> `foces-cecs-projects` team). Until then, ignore that one red check.


### PR DESCRIPTION
Every PR shows a red "Vercel – official-website-v3" check because a second, broken Vercel project is attached to the repo. Investigation (deployment history + Vercel API):

- **`focces`** (personal team `sebins-projects-41e1f03e`) is canonical — owns `focess-five.vercel.app`, deploys fine
- **`official-website-v3`** (team `foces-cecs-projects`) has failed every deployment since the repo first connected (Aug 5) — same commits succeed on `focces`, so it's Vercel-side settings, not code

This documents which project is real so the red check stops being a mystery, and notes the clean fix (disconnect the dead project in the Vercel dashboard).