### PR TITLE
docs: recommend VS Code extensions for one-click junior setup

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,14 @@
+{
+  // Recommended VS Code extensions for this repo — VS Code prompts to install
+  // them when you open the project. Each maps to a tool this repo actually
+  // uses (see .vscode/settings.json, README, CONTRIBUTING).
+  "recommendations": [
+    "esbenp.prettier-vscode", // Prettier formatter (single source of truth for style)
+    "dbaeumer.vscode-eslint", // ESLint — auto-fix on save (settings.json wires it)
+    "editorconfig.editorconfig", // Respects .editorconfig (LF, no trailing whitespace)
+    "bradlc.vscode-tailwindcss", // Tailwind utility autocomplete + hover docs
+    "ms-playwright.playwright", // Run/debug the E2E suite from the editor
+    "vitest.explorer", // Run unit tests and see coverage inline
+    "ms-vscode.vscode-typescript-next" // TypeScript-aware IntelliSense for JS/JSX
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ its docs, a beginner video, and a readable reference.
   📖 [Why pnpm?](https://pnpm.io/motivation)
 - **VS Code** — recommended editor; the repo's settings enable ESLint
   fix-on-save + Prettier format-on-save so your edits are always formatted.
+  On first open, VS Code offers the recommended extensions from
+  [`.vscode/extensions.json`](.vscode/extensions.json) — accept them.
   [Install](https://code.visualstudio.com/download) ·
   [Docs](https://code.visualstudio.com/docs) ·
   🎬 [Official intro videos](https://code.visualstudio.com/docs/getstarted/introvideos)


### PR DESCRIPTION
Adds `.vscode/extensions.json` — VS Code prompts to install the exact extensions this repo's tooling uses (Prettier, ESLint, EditorConfig, Tailwind, Playwright, Vitest) on first open, with a README pointer. All 7 extension IDs verified against the VS Code Marketplace.