### PR TITLE
docs: show contributors how to watch PR checks from the terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ pnpm dev
 Run `pnpm verify` before committing — it runs the whole fast gate (lint,
 format check, unit tests, structural checks, build) in one command.
 
+**Watching PR checks from the terminal:** once a PR is up, follow its CI
+without leaving the terminal —
+`gh pr checks <number> --watch` (set the default repo once with
+`gh repo set-default`). It re-polls until every check settles and prints a
+live table; the [GitHub CLI](https://cli.github.com/) (`gh`) is already
+authorized if you've pushed to this repo, and `gh` is the fastest way to
+open/review/merge PRs too. The checks you'll see: `Lint & Build`, `E2E
+(Playwright)`, `Probes (structural checks)`, and `Validate commit messages`.
+
 ## Tech Stack
 
 - **[React 19](https://react.dev/)** + **[Vite 8](https://vite.dev/)** (SWC plugin)


### PR DESCRIPTION
Adds a short tip in README's Getting started (right after the `pnpm verify` gate) showing `gh pr checks <number> --watch` + `gh repo set-default` — the fastest way to follow a PR's CI without browser tabs, with a note that `gh` is already authorized for anyone who can push to this repo.