### PR TITLE
docs: add knip + actionlint to AGENTS.md verify list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,10 +105,15 @@ one command. The individual steps, if you prefer:
 ```powershell
 pnpm lint          # ESLint 10 flat config, no warnings expected
 pnpm format:check  # Prettier (writes with pnpm format if dirty)
+pnpm knip          # dead-code / unused-dependency guard (CI runs it too — see CONTRIBUTING)
 pnpm build         # production build must succeed
 pnpm test          # Playwright E2E (tests/*.spec.js) — run targeted tests when scoping
 git diff --check   # no whitespace errors
 ```
+
+`pnpm lint:workflows` (actionlint) also runs in the pre-push hook — run it
+manually before pushing if you touched `.github/workflows/` and want the
+check without a push.
 
 For UI/a11y changes, run the relevant probes in `scripts/` against
 `pnpm preview` (per `CONTRIBUTING.md`).


### PR DESCRIPTION
AGENTS.md's verify gate listed lint/format/build/test but not the dead-code guard, even though CI enforces it (`Dead code check` step in Lint & Build) — so an agent could push a branch with unused code and only discover it in CI. Adds `pnpm knip` to the individual steps and a pointer to the actionlint pre-push check for workflow changes.