### PR TITLE
docs: document the yaml-language-server schema hint convention

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 # Auto-merge dependabot PRs once CI passes.
 #
 # GitHub has no native "auto-merge dependabot PRs" flag in dependabot.yml, so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: CI
 
 on:

--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 # Nightly performance run: builds the site, runs the Lighthouse multi-profile
 # probe (8 profiles — desktop, throttled mobile 3G/4G/2G, CPU slowdowns,
 # reduced-motion), enforces budgets, and opens/updates a regression issue if

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: Close stale issues & PRs
 
 on:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,15 @@ pnpm build      # production build (image optimizer + PWA precache)
   `@import` or a side-effect import), add it to `ignoreDependencies` in
   `knip.json` **with a comment explaining why** — never silence a real
   finding just to make the check pass.
+- **YAML config files carry a schema hint where a schema exists**: the
+  top line of `.coderabbit.yaml` and every `.github/workflows/*.yml` is
+  `# yaml-language-server: $schema=...`, so the VS Code YAML extension
+  validates keys and catches typos as you type. When you add or edit a
+  config file, keep or add the matching hint (`https://coderabbit.ai/
+integrations/schema.v2.json` for CodeRabbit, `https://json.schemastore.
+org/github-workflow.json` for workflows). `pnpm-workspace.yaml`
+  intentionally has none — there's no maintained schema for its
+  `allowBuilds` field.
 
 ## Testing
 


### PR DESCRIPTION
## What

Makes the YAML schema-hint convention real instead of aspirational:

- **`.github/workflows/*.yml` (×4)**: added `# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json` as the top line — juniors editing CI YAML now get key validation + autocomplete in VS Code. Verified: actionlint still passes, all four files parse.
- **CONTRIBUTING.md**: new Code expectations bullet documenting the pattern — where the hints live (`.coderabbit.yaml` + all workflows), what to add when creating/editing a config file, and why `pnpm-workspace.yaml` intentionally has none (no maintained schema for `allowBuilds`).

## Why

`.coderabbit.yaml` got its schema hint in #77, but nothing told contributors the convention existed — so the other config files never got one. Now the docs and the files agree.