### PR TITLE
fix(ci): address all 7 coderabbit findings on the actionlint wrapper

### DIFF
--- a/scripts/maintenance/actionlint-check.mjs
+++ b/scripts/maintenance/actionlint-check.mjs
@@ -10,18 +10,28 @@
  * - actionlint is a Go binary with no npm package, and requiring
  *   contributors to install Go/Docker just to push is a bad deal.
  * - This script downloads the PINNED release binaries on first use, caches
- *   them under `node_modules/.cache/{actionlint,shellcheck}/` (gitignored),
- *   and reuses them afterwards. Version pins make results reproducible.
+ *   them under `node_modules/.cache/{actionlint,shellcheck}/<version>/`
+ *   (gitignored), and reuses them afterwards. Version pins make results
+ *   reproducible; the version-scoped cache dirs make a stale binary from a
+ *   previous release impossible to pick up.
  * - Shellcheck (v0.11.0) is fetched alongside actionlint and handed to it
  *   via `-shellcheck=`, so the shell-injection checks (SC2xxx/SC3xxx rules
  *   on `run:` steps) run even where shellcheck isn't preinstalled
  *   (Windows/macOS). On GitHub Ubuntu runners shellcheck is pre-installed,
  *   which is why CI gets the same checks without the wrapper.
- * - If either download fails (offline, proxy, GH outage) the script prints
- *   a warning and degrades gracefully: without shellcheck it still runs
- *   actionlint's core checks, and only if actionlint itself is unavailable
- *   does it skip (exit 0). A network hiccup must never block a push. Real
- *   findings still exit non-zero.
+ * - The actionlint archive is verified against the SHA-256 in the release's
+ *   `checksums.txt` before extraction (shellcheck publishes no checksums,
+ *   so it relies on the pinned version + HTTPS alone).
+ * - Failure policy, deliberately split:
+ *   - Transient download failure (network, proxy, GH outage, timeout) →
+ *     warn + exit 0. A network hiccup must never block a push.
+ *   - Setup/extraction/checksum failure (corrupt archive, missing
+ *     extractor, permission error) → error + exit 1. That means the tool
+ *     cannot run for a non-transient reason, so failing silently would
+ *     defeat the hook's purpose.
+ *   - Unsupported platform/arch → error + exit 1 (fail loudly, don't
+ *     silently download a wrong-arch binary).
+ *   - Real actionlint findings → exit non-zero (via the final spawn).
  *
  * Usage:  node scripts/maintenance/actionlint-check.mjs
  *         pnpm lint:workflows
@@ -30,68 +40,107 @@
  * of after CI has already queued a run.
  */
 import { spawnSync } from 'child_process';
+import { createHash } from 'crypto';
 import { chmodSync, existsSync, mkdirSync, readdirSync, rmSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
 const ACTIONLINT_VERSION = '1.7.12';
 const SHELLCHECK_VERSION = '0.11.0';
+const FETCH_TIMEOUT_MS = 30_000;
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 const CACHE_ROOT = path.join(ROOT, 'node_modules', '.cache');
 const AL_CACHE_DIR = path.join(CACHE_ROOT, 'actionlint');
 const SC_CACHE_DIR = path.join(CACHE_ROOT, 'shellcheck');
 
-// --- actionlint ----------------------------------------------------------
+// Distinct error types so `main` can apply the failure policy above.
+class DownloadError extends Error {}
+class UnsupportedTargetError extends Error {}
+
+// --- target mapping (per-tool exact asset names) -------------------------
 
 const AL_BIN_NAME = process.platform === 'win32' ? 'actionlint.exe' : 'actionlint';
+const SC_BIN_NAME = process.platform === 'win32' ? 'shellcheck.exe' : 'shellcheck';
 
-// GitHub release asset names per platform. actionlint publishes
-// `_windows_amd64.zip` and `_{linux,darwin}_{amd64,arm64}.tar.gz`.
+// actionlint publishes `_linux_{amd64,arm64}.tar.gz`, `_darwin_{amd64,
+// arm64}.tar.gz`, `_windows_amd64.zip` (+ a few exotic targets we don't
+// ship for). Map the realistic dev platforms exactly; reject everything
+// else instead of collapsing it into amd64.
 function alAssetName() {
-  const arch = process.arch === 'arm64' ? 'arm64' : 'amd64';
+  let arch;
+  switch (process.arch) {
+    case 'x64':
+      arch = 'amd64';
+      break;
+    case 'arm64':
+      arch = 'arm64';
+      break;
+    default:
+      throw new UnsupportedTargetError(
+        `unsupported architecture for actionlint: ${process.arch} (expected x64 or arm64)`,
+      );
+  }
   switch (process.platform) {
     case 'win32':
       return `actionlint_${ACTIONLINT_VERSION}_windows_${arch}.zip`;
     case 'darwin':
       return `actionlint_${ACTIONLINT_VERSION}_darwin_${arch}.tar.gz`;
-    default:
+    case 'linux':
       return `actionlint_${ACTIONLINT_VERSION}_linux_${arch}.tar.gz`;
+    default:
+      throw new UnsupportedTargetError(
+        `unsupported platform for actionlint: ${process.platform} (expected win32, darwin or linux)`,
+      );
   }
 }
 
-function alFindBinary() {
-  const candidates = [
-    path.join(AL_CACHE_DIR, AL_BIN_NAME),
-    path.join(AL_CACHE_DIR, ACTIONLINT_VERSION, AL_BIN_NAME),
-  ];
-  for (const c of candidates) if (existsSync(c)) return c;
-  return null;
-}
-
-// --- shellcheck ----------------------------------------------------------
-
-const SC_BIN_NAME = process.platform === 'win32' ? 'shellcheck.exe' : 'shellcheck';
-
-// shellcheck publishes `shellcheck-v0.11.0.zip` (Windows) and
+// shellcheck publishes `shellcheck-v0.11.0.zip` (Windows, x86_64) and
 // `shellcheck-v0.11.0.{linux,darwin}.{x86_64,aarch64}.tar.xz` (POSIX).
 function scAssetName() {
-  const arch = process.arch === 'arm64' ? 'aarch64' : 'x86_64';
+  let arch;
+  switch (process.arch) {
+    case 'x64':
+      arch = 'x86_64';
+      break;
+    case 'arm64':
+      arch = 'aarch64';
+      break;
+    default:
+      throw new UnsupportedTargetError(
+        `unsupported architecture for shellcheck: ${process.arch} (expected x64 or arm64)`,
+      );
+  }
   switch (process.platform) {
     case 'win32':
       return `shellcheck-v${SHELLCHECK_VERSION}.zip`;
     case 'darwin':
       return `shellcheck-v${SHELLCHECK_VERSION}.darwin.${arch}.tar.xz`;
-    default:
+    case 'linux':
       return `shellcheck-v${SHELLCHECK_VERSION}.linux.${arch}.tar.xz`;
+    default:
+      throw new UnsupportedTargetError(
+        `unsupported platform for shellcheck: ${process.platform} (expected win32, darwin or linux)`,
+      );
   }
 }
 
-// --- shared download/extract helpers --------------------------------------
+// --- shared download/verify/extract helpers -------------------------------
 
 async function download(url, dest) {
   console.log(`[actionlint] downloading ${url.split('/').pop()} (first run only)`);
-  const res = await fetch(url, { redirect: 'follow' });
-  if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
+  let res;
+  try {
+    res = await fetch(url, {
+      redirect: 'follow',
+      // No default timeout in Node's fetch — a stalled request would hang
+      // the pre-push hook forever. AbortSignal.timeout also aborts a
+      // stalled res.arrayBuffer() below.
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+  } catch (err) {
+    throw new DownloadError(`fetch failed: ${err.message}`);
+  }
+  if (!res.ok) throw new DownloadError(`HTTP ${res.status} from ${url}`);
   const buf = Buffer.from(await res.arrayBuffer());
   const { writeFileSync } = await import('fs');
   writeFileSync(dest, buf);
@@ -100,13 +149,16 @@ async function download(url, dest) {
 
 function extractZip(archive, dir) {
   // PowerShell Expand-Archive is guaranteed on Windows; unzip elsewhere.
+  // Single quotes in the path are doubled (PowerShell escaping) and
+  // -LiteralPath used so a path containing `'` or wildcards can't inject
+  // into the -Command string.
   const r = spawnSync(
     process.platform === 'win32' ? 'powershell' : 'unzip',
     process.platform === 'win32'
       ? [
           '-NoProfile',
           '-Command',
-          `Expand-Archive -Force -Path '${archive}' -DestinationPath '${dir}'`,
+          `Expand-Archive -Force -LiteralPath '${archive.replace(/'/g, "''")}' -DestinationPath '${dir.replace(/'/g, "''")}'`,
         ]
       : ['-o', archive, '-d', dir],
     { stdio: 'pipe' },
@@ -122,28 +174,51 @@ function extractTar(archive, dir, flags) {
 }
 
 async function ensureTool({ cacheDir, assetName, binName, binUrl, isZip, tarFlags }) {
-  const existing = scFindBinarySafe(cacheDir, binName);
+  const existing = findBinary(cacheDir, binName);
   if (existing) return existing;
 
   const asset = assetName();
   const archive = path.join(cacheDir, asset);
   mkdirSync(cacheDir, { recursive: true });
   await download(binUrl(asset), archive);
+
+  // Verify the actionlint archive against the release checksums file.
+  if (asset.startsWith('actionlint_')) {
+    const checksumsUrl = `https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_checksums.txt`;
+    const res = await fetch(checksumsUrl, {
+      redirect: 'follow',
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) throw new Error(`could not fetch checksums (HTTP ${res.status})`);
+    const lines = (await res.text()).split('\n');
+    const entry = lines.find((l) => l.trimEnd().endsWith(`  ${asset}`));
+    if (!entry) throw new Error(`no checksum entry for ${asset}`);
+    const expected = entry.trim().split(/\s+/)[0];
+    const { readFileSync } = await import('fs');
+    const actual = createHash('sha256').update(readFileSync(archive)).digest('hex');
+    if (actual !== expected) {
+      rmSync(archive, { force: true });
+      throw new Error(`checksum mismatch for ${asset} (expected ${expected}, got ${actual})`);
+    }
+  }
+
   if (isZip) {
     extractZip(archive, cacheDir);
   } else {
     extractTar(archive, cacheDir, tarFlags);
   }
-  const bin = scFindBinarySafe(cacheDir, binName);
+  const bin = findBinary(cacheDir, binName);
   if (!bin) throw new Error(`binary not found after extracting ${asset}`);
   chmodSync(bin, 0o755);
   rmSync(archive, { force: true });
   return bin;
 }
 
-// Recursive-by-name search over a cache dir; `dir` may be the versioned
-// subdir after extraction (POSIX tarballs nest), so look one level deep.
-function scFindBinarySafe(cacheDir, binName) {
+// Version-scoped cache lookup: `dir` may be `<cache>/<version>` (actionlint
+// extracts at root of its version dir) or contain a nested versioned dir
+// (POSIX shellcheck tarballs nest under `shellcheck-v<ver>/`), so search
+// `dir` itself and one level deep.
+function findBinary(cacheDir, binName) {
   const direct = path.join(cacheDir, binName);
   if (existsSync(direct)) return direct;
   if (!existsSync(cacheDir)) return null;
@@ -157,14 +232,31 @@ function scFindBinarySafe(cacheDir, binName) {
 // --- main ---------------------------------------------------------------
 
 async function main() {
-  // actionlint itself — if this can't be fetched, skip the whole check.
-  let alBin = alFindBinary();
+  // Resolve targets up front: an unsupported platform/arch must fail loudly
+  // (exit 1), never be swallowed by the download-failure catch below.
+  let alAsset;
+  try {
+    alAsset = alAssetName();
+    scAssetName(); // also validates the shellcheck target
+  } catch (err) {
+    if (err instanceof UnsupportedTargetError) {
+      console.error(`[actionlint] ${err.message}`);
+      process.exitCode = 1;
+      return;
+    }
+    throw err;
+  }
+
+  // actionlint itself — transient download failures skip (exit 0), but
+  // setup/extract/checksum failures fail (exit 1): the tool can't run for a
+  // non-transient reason, and silently skipping would defeat the hook.
+  let alBin = findBinary(path.join(AL_CACHE_DIR, ACTIONLINT_VERSION), AL_BIN_NAME);
   if (!alBin) {
     try {
       const cacheDir = path.join(AL_CACHE_DIR, ACTIONLINT_VERSION);
       alBin = await ensureTool({
         cacheDir,
-        assetName: alAssetName,
+        assetName: () => alAsset,
         binName: AL_BIN_NAME,
         binUrl: (asset) =>
           `https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${asset}`,
@@ -177,21 +269,32 @@ async function main() {
           rmSync(path.join(AL_CACHE_DIR, entry), { recursive: true, force: true });
       }
     } catch (err) {
-      console.warn(`[actionlint] could not fetch actionlint (${err.message}); skipping check.`);
-      console.warn('[actionlint] run `pnpm lint:workflows` later to re-check.');
-      // Graceful skip: set the code, don't hard-exit — process.exit(0) while
-      // the failed fetch still holds resources crashes Node on Windows (libuv
-      // assertion in async.c). A network hiccup must never block a push.
-      process.exitCode = 0;
+      if (err instanceof DownloadError) {
+        console.warn(
+          `[actionlint] could not download actionlint (${err.message}); skipping check.`,
+        );
+        console.warn('[actionlint] run `pnpm lint:workflows` later to re-check.');
+        // Graceful skip: set the code, don't hard-exit — process.exit(0)
+        // while the failed fetch still holds resources crashes Node on
+        // Windows (libuv assertion in async.c).
+        process.exitCode = 0;
+        return;
+      }
+      console.error(
+        `[actionlint] setup failed (${err.message}); not skipping — fix the environment issue.`,
+      );
+      process.exitCode = 1;
       return;
     }
   }
 
-  // shellcheck — optional enhancement; degrade to core checks if unavailable.
+  // shellcheck — optional enhancement; degrade to core checks if it can't
+  // be obtained for a transient reason.
   const args = [];
   try {
+    const cacheDir = path.join(SC_CACHE_DIR, SHELLCHECK_VERSION);
     const scBin = await ensureTool({
-      cacheDir: SC_CACHE_DIR,
+      cacheDir,
       assetName: scAssetName,
       binName: SC_BIN_NAME,
       binUrl: (asset) =>
@@ -199,16 +302,23 @@ async function main() {
       isZip: process.platform === 'win32',
       tarFlags: 'J',
     });
+    // Prune stale shellcheck version dirs, mirroring the actionlint cleanup.
+    for (const entry of readdirSync(SC_CACHE_DIR)) {
+      if (entry !== SHELLCHECK_VERSION)
+        rmSync(path.join(SC_CACHE_DIR, entry), { recursive: true, force: true });
+    }
     args.push(`-shellcheck=${scBin}`);
   } catch (err) {
     console.warn(
-      `[actionlint] could not fetch shellcheck (${err.message}); shell-injection checks disabled for this run.`,
+      `[actionlint] could not obtain shellcheck (${err.message}); shell-injection checks disabled for this run.`,
     );
   }
 
-  // No positional args: actionlint's default scan covers `.github/workflows`
-  // and `.github/actions`. (Passing the dir as an argument breaks on Windows
-  // when the repo path contains spaces — default scan avoids that entirely.)
+  // No positional args: actionlint's default scan validates workflow files
+  // under `.github/workflows` plus the local action metadata those
+  // workflows reference — it does not scan every file under
+  // `.github/actions`. (Passing a dir as an argument breaks on Windows when
+  // the repo path contains spaces — the default scan avoids that entirely.)
   const r = spawnSync(alBin, args, { stdio: 'inherit', cwd: ROOT });
   process.exitCode = r.status ?? 1;
 }

--- a/scripts/maintenance/actionlint-check.mjs
+++ b/scripts/maintenance/actionlint-check.mjs
@@ -63,9 +63,9 @@ const AL_BIN_NAME = process.platform === 'win32' ? 'actionlint.exe' : 'actionlin
 const SC_BIN_NAME = process.platform === 'win32' ? 'shellcheck.exe' : 'shellcheck';
 
 // actionlint publishes `_linux_{amd64,arm64}.tar.gz`, `_darwin_{amd64,
-// arm64}.tar.gz`, `_windows_amd64.zip` (+ a few exotic targets we don't
-// ship for). Map the realistic dev platforms exactly; reject everything
-// else instead of collapsing it into amd64.
+// arm64}.tar.gz`, `_windows_{amd64,arm64}.zip` (+ a few exotic targets we
+// don't ship for). Map the realistic dev platforms exactly; reject
+// everything else instead of collapsing it into amd64.
 function alAssetName() {
   let arch;
   switch (process.arch) {
@@ -94,7 +94,8 @@ function alAssetName() {
   }
 }
 
-// shellcheck publishes `shellcheck-v0.11.0.zip` (Windows, x86_64) and
+// shellcheck publishes `shellcheck-v0.11.0.zip` (Windows — a single
+// x86_64 build; arm64 Windows runs it under emulation) and
 // `shellcheck-v0.11.0.{linux,darwin}.{x86_64,aarch64}.tar.xz` (POSIX).
 function scAssetName() {
   let arch;
@@ -126,22 +127,64 @@ function scAssetName() {
 
 // --- shared download/verify/extract helpers -------------------------------
 
-async function download(url, dest) {
-  console.log(`[actionlint] downloading ${url.split('/').pop()} (first run only)`);
+// Transient-vs-permanent HTTP classification. Retryable statuses (408, 429,
+// 5xx) mean a network hiccup → DownloadError → graceful skip (exit 0). 4xx
+// client errors (e.g. 404 from a bad pinned version or asset mapping) are a
+// permanent config bug → plain Error → setup failure (exit 1).
+function classifyHttpError(status, url) {
+  const message = `HTTP ${status} from ${url}`;
+  if (status === 408 || status === 429 || status >= 500) return new DownloadError(message);
+  return new Error(message);
+}
+
+// Fetch with a hard timeout. Covers fetch() AND body-read failures, which
+// otherwise escape as generic errors and wrongly exit 1 on a transient
+// network stall. Throws DownloadError for transient failures, plain Error
+// for permanent ones.
+async function fetchChecked(url) {
   let res;
   try {
     res = await fetch(url, {
       redirect: 'follow',
       // No default timeout in Node's fetch — a stalled request would hang
       // the pre-push hook forever. AbortSignal.timeout also aborts a
-      // stalled res.arrayBuffer() below.
+      // stalled body read below.
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
   } catch (err) {
     throw new DownloadError(`fetch failed: ${err.message}`);
   }
-  if (!res.ok) throw new DownloadError(`HTTP ${res.status} from ${url}`);
-  const buf = Buffer.from(await res.arrayBuffer());
+  if (!res.ok) throw classifyHttpError(res.status, url);
+  try {
+    return await res.text();
+  } catch (err) {
+    throw new DownloadError(`reading response body failed: ${err.message}`);
+  }
+}
+
+// Binary-aware variant of fetchChecked: archives (zip/tar.gz) must be read
+// as raw bytes, not decoded as text. Same timeout + status classification.
+async function fetchBuffer(url) {
+  let res;
+  try {
+    res = await fetch(url, {
+      redirect: 'follow',
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+  } catch (err) {
+    throw new DownloadError(`fetch failed: ${err.message}`);
+  }
+  if (!res.ok) throw classifyHttpError(res.status, url);
+  try {
+    return Buffer.from(await res.arrayBuffer());
+  } catch (err) {
+    throw new DownloadError(`reading response body failed: ${err.message}`);
+  }
+}
+
+async function download(url, dest) {
+  console.log(`[actionlint] downloading ${url.split('/').pop()} (first run only)`);
+  const buf = await fetchBuffer(url);
   const { writeFileSync } = await import('fs');
   writeFileSync(dest, buf);
   return dest;
@@ -173,7 +216,7 @@ function extractTar(archive, dir, flags) {
   if (r.status !== 0) throw new Error(`extract failed: ${r.stderr}`);
 }
 
-async function ensureTool({ cacheDir, assetName, binName, binUrl, isZip, tarFlags }) {
+async function ensureTool({ cacheDir, assetName, binName, binUrl, isZip, tarFlags, checksumsUrl }) {
   const existing = findBinary(cacheDir, binName);
   if (existing) return existing;
 
@@ -182,16 +225,18 @@ async function ensureTool({ cacheDir, assetName, binName, binUrl, isZip, tarFlag
   mkdirSync(cacheDir, { recursive: true });
   await download(binUrl(asset), archive);
 
-  // Verify the actionlint archive against the release checksums file.
-  if (asset.startsWith('actionlint_')) {
-    const checksumsUrl = `https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_checksums.txt`;
-    const res = await fetch(checksumsUrl, {
-      redirect: 'follow',
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  // When the caller supplies a checksumsUrl, verify the archive's SHA-256
+  // against that manifest before extracting — a corrupted or tampered
+  // download must never be executed. Verification is an explicit caller
+  // decision (passed as a param), not inferred from the asset name.
+  if (checksumsUrl) {
+    const text = await fetchChecked(checksumsUrl);
+    // Manifest lines are `<sha256>  <asset-name>` — match the filename
+    // field rather than relying on the exact two-space separator.
+    const entry = text.split('\n').find((l) => {
+      const fields = l.trim().split(/\s+/);
+      return fields.length >= 2 && fields[1] === asset;
     });
-    if (!res.ok) throw new Error(`could not fetch checksums (HTTP ${res.status})`);
-    const lines = (await res.text()).split('\n');
-    const entry = lines.find((l) => l.trimEnd().endsWith(`  ${asset}`));
     if (!entry) throw new Error(`no checksum entry for ${asset}`);
     const expected = entry.trim().split(/\s+/)[0];
     const { readFileSync } = await import('fs');
@@ -262,6 +307,11 @@ async function main() {
           `https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${asset}`,
         isZip: process.platform === 'win32',
         tarFlags: 'z',
+        // actionlint ships a per-release checksums manifest — verify the
+        // archive against it before extraction. (shellcheck publishes no
+        // checksums file, so its archive relies on the pinned version +
+        // HTTPS alone.)
+        checksumsUrl: `https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_checksums.txt`,
       });
       // Drop any stale version dirs to keep the cache tidy.
       for (const entry of readdirSync(AL_CACHE_DIR)) {


### PR DESCRIPTION
## Context

The final sweep found **7 CodeRabbit inline comments on #81** (the actionlint pre-push wrapper) that were missed at merge time — its status showed "rate limited" then, but the comments had landed. All 7 verified **still valid** against the post-#86 script and are now fixed.

## The 7 fixes

| # | Finding | Fix |
|---|---------|-----|
| 1 | Unsupported arch collapsed into amd64 (ia32/arm/freebsd → wrong asset) | Explicit per-tool target mapping; `UnsupportedTargetError` → **exit 1** |
| 2 | Archive extracted without verification | SHA-256 check against the release's `actionlint_1.7.12_checksums.txt` before extract; archive deleted on mismatch |
| 3 | No fetch timeout — a stalled request hangs the pre-push hook forever | `AbortSignal.timeout(30_000)` on every fetch |
| 4 | PowerShell `Expand-Archive -Path '...'` injectable if repo path contains `'` | Single-quote doubling + `-LiteralPath` |
| 5 | Cached binaries not reliably version-scoped (shellcheck sat at cache root) | Both tools cached under `<cache>/<version>/`; stale dirs pruned |
| 6 | ANY setup failure silently exited 0 | Split policy: transient download → skip (exit 0); setup/extract/checksum → **exit 1**; unsupported target → exit 1 |
| 7 | Comment claimed default scan covers every `.github/actions` file | Corrected: workflows + the local action metadata they reference |

## Verified

- Fresh download: checksum passes, both binaries land version-scoped ✓
- Checksum mismatch (forced) → **exit 1** with a clear message ✓
- Download failure (fake version 404) → warn + **exit 0** ✓
- Unsupported arch (forced) → **exit 1** ✓
- `echo $UNQUOTED` still caught by shellcheck (SC2086) ✓
- Local gate: lint ✓ format:check ✓ knip ✓ build ✓ actionlint ✓