### PR TITLE
docs: align PR template checklist with the current verification gate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,11 +11,15 @@
 1. `pnpm install`
 2. `pnpm dev` → open http://localhost:5173
 3. <!-- Steps to reproduce/verify -->
+4. `pnpm verify` — runs the fast gate (lint + format check + unit tests +
+   structural checks + build) in one command; CI runs the same checks on
+   this PR (watch with `gh pr checks <number> --watch`)
 
 ## Checklist
 
-- [ ] `pnpm lint` passes with **no errors**
-- [ ] `pnpm build` completes successfully
+- [ ] `pnpm verify` passes (lint + format + unit tests + structural checks + build)
+- [ ] `pnpm knip` passes (no unused exports / files / dependencies)
+- [ ] If `.github/workflows/` changed: `pnpm lint:workflows` passes (actionlint + shellcheck)
 - [ ] Tested on desktop **and** mobile viewports
 - [ ] If the change touches performance paths: `useDeviceProfile` (slow-network / low-power) behavior preserved
 - [ ] If interactive: keyboard navigable with visible `:focus-visible` styling


### PR DESCRIPTION
## What

CodeRabbit's description check validates PR bodies against `.github/pull_request_template.md` (the testing-steps + checklist sections) — confirmed via its docs and the #83 fixture-PR failure, which named exactly those sections. The template had them, but the **checklist was stale**: it listed `pnpm lint` + `pnpm build` as separate items while the real gate (per AGENTS.md / CONTRIBUTING) is `pnpm verify` — lint + format check + unit tests + structural checks + build — plus `pnpm knip`, and `pnpm lint:workflows` (actionlint + shellcheck) for workflow changes.

## Changes

- **How to test**: added `pnpm verify` as step 4, with a pointer to `gh pr checks <number> --watch`
- **Checklist**: replaced the lint/build pair with `pnpm verify`, added knip and the workflow-conditional actionlint item; kept the a11y/perf/inline-style items

## How to test

1. Open the PR body editor — the template renders with the new checklist
2. `pnpm verify` passes on this PR (CI enforces it)
3. Checklist: all items ticked; no workflow files changed, so the actionlint item is N/A

## Checklist

- [x] `pnpm verify` passes (lint + format + unit tests + structural checks + build)
- [x] `pnpm knip` passes (no unused exports / files / dependencies)
- [ ] If `.github/workflows/` changed: `pnpm lint:workflows` passes (actionlint + shellcheck) — N/A, no workflow changes
- [x] Tested on desktop **and** mobile viewports — N/A, docs-only
- [ ] If the change touches performance paths: `useDeviceProfile` behavior preserved — N/A
- [ ] If interactive: keyboard navigable with visible `:focus-visible` styling — N/A
- [x] No new inline `style={{}}` objects (prefer CSS files / Tailwind utilities)