### PR TITLE
test: cover riscv64 rejection for shellcheck assets

### DIFF
--- a/tests/unit/actionlintCheck.spec.js
+++ b/tests/unit/actionlintCheck.spec.js
@@ -122,6 +122,7 @@ describe('scAssetName — shellcheck release asset per platform/arch', () => {
   it.each([
     ['ia32', 'x64'],
     ['arm', 'x64'],
+    ['riscv64', 'x64'],
   ])('rejects unsupported arch (%s, %s)', (arch, platform) => {
     setTarget(platform, arch);
     expect(() => scAssetName()).toThrow(UnsupportedTargetError);


### PR DESCRIPTION
## What does this PR do?

Adds `riscv64` to the shellcheck unsupported-arch rejection cases in `actionlintCheck.spec.js` — mirroring the `alAssetName` spec, which already covers it. `scAssetName` rejects it via the same `UnsupportedTargetError` default case, so this closes a spec-coverage gap.

This also serves as a fresh CodeRabbit review target: it touches the spec file behind the wrapper's failure-classification tests (#91) and the wrapper itself (#81/#88/#90) so a re-review can confirm all prior findings stay closed.

## Screenshots / recordings

N/A — test-only change.

## How to test

1. `pnpm exec vitest run tests/unit/actionlintCheck.spec.js` — 18 tests pass.
2. `pnpm verify` — fast gate.
3. `gh pr checks <number> --watch` — CI + CodeRabbit review.

## Checklist

- [x] `pnpm verify` passes (lint + format + unit tests + structural checks + build)
- [x] `pnpm knip` passes (no unused exports / files / dependencies)
- [ ] If `.github/workflows/` changed: `pnpm lint:workflows` passes (actionlint + shellcheck) — N/A
- [x] Tested on desktop **and** mobile viewports — N/A (test-only)
- [ ] If the change touches performance paths: `useDeviceProfile` (slow-network / low-power) behavior preserved — N/A
- [ ] If interactive: keyboard navigable with visible `:focus-visible` styling — N/A
- [x] No new inline `style={{}}` objects (prefer CSS files / Tailwind utilities) — N/A