### PR TITLE
feat: blur-up LQIP loading + FOCES logo on the coffee mug loader

### DIFF
--- a/src/Components/Execom/Execom.jsx
+++ b/src/Components/Execom/Execom.jsx
@@ -56,6 +56,7 @@ function Execom() {
               <BlurImage
                 className="object-cover object-top w-full h-full grayscale group-hover:filter-none transition-all duration-500"
                 src={advisor.img}
+                blurSrc={advisor.blur}
                 alt={advisor.name}
                 loading="lazy"
                 decoding="async"

--- a/src/Components/Execom/Execom.jsx
+++ b/src/Components/Execom/Execom.jsx
@@ -56,7 +56,6 @@ function Execom() {
               <BlurImage
                 className="object-cover object-top w-full h-full grayscale group-hover:filter-none transition-all duration-500"
                 src={advisor.img}
-                blurSrc={advisor.blur}
                 alt={advisor.name}
                 loading="lazy"
                 decoding="async"

--- a/src/Components/Execom/TeamCarousel.jsx
+++ b/src/Components/Execom/TeamCarousel.jsx
@@ -156,7 +156,6 @@ function TeamCarousel({
                   d.name === 'Sebin Mathew' ? 'object-center' : 'object-top'
                 } w-full h-full ${isDesktop ? 'card-hover' : ''} grayscale group-hover:filter-none transition-all duration-300`}
                 src={d.img}
-                blurSrc={d.blur}
                 alt={d.name}
                 loading="lazy"
                 decoding="async"

--- a/src/Components/Loader/Loader.css
+++ b/src/Components/Loader/Loader.css
@@ -52,6 +52,21 @@
     -webkit-animation: coffee 2s infinite;
     animation: coffee 2s infinite;
 }
+
+/* FOCES wordmark on the mug face — centered, above the coffee bars and the
+   white cup background (z-index), but small enough that the cup and its bars
+   stay visible around it. Absolute positioning also removes it from the
+   coffee grid, so the 5 bars keep their columns. */
+.coffee-logo {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 38px;
+    height: auto;
+    z-index: 2;
+    pointer-events: none;
+}
 .coffee div:nth-child(1) {
     -webkit-animation-delay: 0.4s;
     animation-delay: 0.4s;

--- a/src/Components/Loader/Loader.jsx
+++ b/src/Components/Loader/Loader.jsx
@@ -1,6 +1,7 @@
 import './Loader.css';
 import { useViewportWidth } from '../../hooks/useViewportWidth.js';
 import { isSmallScreen } from '../../utils/breakpoints.js';
+import LogoBlack from '../../assets/FOCES Black.svg';
 
 const Loader = () => {
   // Narrow-screen tagline pick: policy in breakpoints.js, reactivity from
@@ -27,6 +28,18 @@ const Loader = () => {
           <span className="steam-dot" />
         </div>
         <div className="coffee">
+          {/* FOCES wordmark on the mug face. Absolutely positioned (taken out
+              of the coffee grid) and sized so the cup + bars stay visible
+              around it — the mug must not disappear behind the logo. Black
+              variant: the mug face is white. */}
+          <img
+            src={LogoBlack}
+            alt=""
+            aria-hidden="true"
+            loading="eager"
+            decoding="async"
+            className="coffee-logo"
+          />
           <div></div>
           <div></div>
           <div></div>

--- a/src/Pages/EventPage/EventCard.jsx
+++ b/src/Pages/EventPage/EventCard.jsx
@@ -91,6 +91,9 @@ function EventCard({ Events, priority, reverse }) {
               src={primary.url}
               srcSet={primary.srcset}
               sizes={`(min-width: ${DESKTOP_MIN}px) 50vw, 92vw`}
+              // Only the first event's primary carries an LQIP (see
+              // src/data/events.js); every other photo lazy-loads plainly.
+              blurSrc={priority ? primary.blur : undefined}
               alt={Events.name}
               loading={priority ? 'eager' : 'lazy'}
               decoding="async"

--- a/src/Pages/LandingPages/Events.jsx
+++ b/src/Pages/LandingPages/Events.jsx
@@ -51,6 +51,10 @@ function Events() {
                   src={evt.photos[0].url}
                   srcSet={evt.photos[0].srcset}
                   sizes={`(min-width: ${WIDE_SCREEN_MIN}px) 30vw, (min-width: ${DESKTOP_MIN}px) 45vw, 90vw`}
+                  // Only the FIRST event's banner carries an LQIP (see
+                  // src/data/events.js) — the other cards lazy-load plainly,
+                  // matching the events page first-card behavior.
+                  blurSrc={index === 0 ? evt.photos[0].blur : undefined}
                   alt={evt.name}
                   loading={index === 0 ? 'eager' : 'lazy'}
                   decoding="async"

--- a/src/Pages/LandingPages/Featuring.jsx
+++ b/src/Pages/LandingPages/Featuring.jsx
@@ -6,6 +6,7 @@ import 'swiper/css';
 import { FaChevronLeft, FaChevronRight } from 'react-icons/fa6';
 import useDeviceProfile from '../../hooks/useLowPower.js';
 import { useAutoplayOnScreen } from '../../hooks/useAutoplayOnScreen.js';
+import BlurImage from '../../Components/BlurImage/BlurImage';
 import featuring from '../../assets/featuring.svg';
 import { echoSlides, carouselSlides } from '../../data/echoSlides.js';
 import { featuringSlidesPerView, DESKTOP_MIN, SMALL_SCREEN_MAX } from '../../utils/breakpoints.js';
@@ -134,19 +135,24 @@ function Featuring() {
           onTransitionEnd={handleWrap}
           className="feat-swiper bg-transparent h-fit"
         >
-          {carouselSlides.map(({ image, imageSet, alt }, index) => (
+          {carouselSlides.map(({ image, imageSet, blur, alt }, index) => (
             <SwiperSlide key={index} className="px-3 pt-9 pb-8 bg-transparent">
-              <img
-                className="h-full w-full rounded-2xl object-cover transition-all duration-300 shadow-xl hover:scale-105 hover:ring-2 hover:ring-white/50 hover:shadow-[0_0_25px_6px_rgba(255,255,255,0.25)]"
-                src={image}
-                srcSet={imageSet}
-                sizes={`(min-width: ${DESKTOP_MIN}px) 33vw, (min-width: ${SMALL_SCREEN_MAX}px) 50vw, 90vw`}
-                alt={alt}
-                loading="lazy"
-                decoding="async"
-                data-aos="flip-right"
-                data-aos-duration="1000"
-              />
+              {/* data-aos lives on the wrapper, not the img: AOS's [data-aos]
+                  opacity rules would override the blur-up fade (higher CSS
+                  specificity than Tailwind's opacity-0/100), so the reveal
+                  animates the whole card while BlurImage fades independently. */}
+              <div data-aos="flip-right" data-aos-duration="1000">
+                <BlurImage
+                  className="h-full w-full rounded-2xl object-cover transition-all duration-300 shadow-xl hover:scale-105 hover:ring-2 hover:ring-white/50 hover:shadow-[0_0_25px_6px_rgba(255,255,255,0.25)]"
+                  src={image}
+                  srcSet={imageSet}
+                  sizes={`(min-width: ${DESKTOP_MIN}px) 33vw, (min-width: ${SMALL_SCREEN_MAX}px) 50vw, 90vw`}
+                  blurSrc={blur}
+                  alt={alt}
+                  loading="lazy"
+                  decoding="async"
+                />
+              </div>
             </SwiperSlide>
           ))}
         </Swiper>

--- a/src/data/echoSlides.js
+++ b/src/data/echoSlides.js
@@ -5,15 +5,19 @@
 import episodeOne from '../assets/episode-1.webp';
 import episodeOne480 from '../assets/episode-1-480.webp';
 import episodeOne960 from '../assets/episode-1-960.webp';
+import episodeOneBlur from '../assets/episode-1.webp?blur&w=128';
 import series from '../assets/series.webp';
 import series480 from '../assets/series-480.webp';
 import series960 from '../assets/series-960.webp';
+import seriesBlur from '../assets/series.webp?blur&w=128';
 import fourth from '../assets/fourth.webp';
 import fourth480 from '../assets/fourth-480.webp';
 import fourth960 from '../assets/fourth-960.webp';
+import fourthBlur from '../assets/fourth.webp?blur&w=128';
 import mentorReveal from '../assets/Mentor_reveal.webp';
 import mentorReveal480 from '../assets/Mentor_reveal-480.webp';
 import mentorReveal960 from '../assets/Mentor_reveal-960.webp';
+import mentorRevealBlur from '../assets/Mentor_reveal.webp?blur&w=128';
 import { srcset } from '../utils/srcset.js';
 
 export const echoSlides = [
@@ -24,6 +28,7 @@ export const echoSlides = [
       [episodeOne960, 960],
       [episodeOne480, 480],
     ]),
+    blur: episodeOneBlur,
     alt: 'ECHO - Episode 1',
   },
   {
@@ -33,6 +38,7 @@ export const echoSlides = [
       [series960, 960],
       [series480, 480],
     ]),
+    blur: seriesBlur,
     alt: 'ECHO Series',
   },
   {
@@ -42,6 +48,7 @@ export const echoSlides = [
       [mentorReveal960, 960],
       [mentorReveal480, 480],
     ]),
+    blur: mentorRevealBlur,
     alt: 'ECHO - Mentor Reveal',
   },
   {
@@ -51,6 +58,7 @@ export const echoSlides = [
       [fourth960, 960],
       [fourth480, 480],
     ]),
+    blur: fourthBlur,
     alt: 'ECHO - Fourth',
   },
 ];

--- a/src/data/events.js
+++ b/src/data/events.js
@@ -18,6 +18,10 @@ import codingArenaPhoto800 from '../assets/coding_arena-800.webp';
 import promptParadoxPoster from '../assets/the_prompt_paradox_2_0_insta.webp';
 import promptParadoxPoster400 from '../assets/the_prompt_paradox_2_0_insta-400.webp';
 import promptParadoxPoster800 from '../assets/the_prompt_paradox_2_0_insta-800.webp';
+// The FIRST event's primary photo is the only events image with a blur-up
+// placeholder. w=128 (vs the team's w=20) keeps enough minimal detail to
+// read as a poster while it loads — still a sub-1KB LQIP.
+import promptParadoxPosterBlur from '../assets/the_prompt_paradox_2_0_insta.webp?blur&w=128';
 
 // High resolution event photos & video frame extractions
 import agenticMentor from '../assets/events/agentic_workshop_mentor.webp';
@@ -49,7 +53,12 @@ export const featuredEvents = [
     tag: 'AI & Prompt Engineering',
     date: '21st June 2026',
     photos: [
-      photoTriplet(promptParadoxPoster, promptParadoxPoster800, promptParadoxPoster400),
+      photoTriplet(
+        promptParadoxPoster,
+        promptParadoxPoster800,
+        promptParadoxPoster400,
+        promptParadoxPosterBlur,
+      ),
       photoTriplet(promptParadoxWinners, promptParadoxWinners800, promptParadoxWinners400),
       photoTriplet(
         promptParadoxLeaderboard,

--- a/src/data/team.js
+++ b/src/data/team.js
@@ -14,6 +14,10 @@ import Anjitha from '../assets/anjitha.webp';
 import Abhirami from '../assets/abhirami_p.webp';
 import Devadarsana from '../assets/devadarsana.webp?v=3';
 import Gopakumar from '../assets/gopakumar.webp';
+// The advisor banner is the FIRST image in the Execom section — it gets the
+// blur-up LQIP treatment (w=128) while the carousel cards stay plain lazy
+// loads (blur-up only where it's the section's lead image).
+import GopakumarBlur from '../assets/gopakumar.webp?blur&w=128';
 
 export const cardData = [
   { name: 'Aleetta Mariya Sebastian', img: Aleetta, role: 'Chairperson' },
@@ -39,5 +43,6 @@ export const cubeSlides = [...cardData, ...cardData, ...cardData];
 export const advisor = {
   name: 'Gopakumar G',
   img: Gopakumar,
+  blur: GopakumarBlur,
   role: 'Advisor',
 };

--- a/src/data/team.js
+++ b/src/data/team.js
@@ -3,45 +3,32 @@
 // shape guard (src/utils/validateTeam.js) pin it in CI like events, and keeps
 // the layout component readable.
 import Aleetta from '../assets/aleeta.webp';
-import AleettaBlur from '../assets/aleeta.webp?blur&w=20';
 import Lisha from '../assets/lisha1.webp';
-import LishaBlur from '../assets/lisha1.webp?blur&w=20';
 import Steve from '../assets/steve.webp';
-import SteveBlur from '../assets/steve.webp?blur&w=20';
 import AnnaRachel from '../assets/anna_rachel.webp';
-import AnnaRachelBlur from '../assets/anna_rachel.webp?blur&w=20';
 import Amanul from '../assets/amanul.webp';
-import AmanulBlur from '../assets/amanul.webp?blur&w=20';
 import Abel from '../assets/abel.webp';
-import AbelBlur from '../assets/abel.webp?blur&w=20';
 import Saniya from '../assets/saniya.webp';
-import SaniyaBlur from '../assets/saniya.webp?blur&w=20';
 import Sebin from '../assets/sebin.webp';
-import SebinBlur from '../assets/sebin.webp?blur&w=20';
 import Anjitha from '../assets/anjitha.webp';
-import AnjithaBlur from '../assets/anjitha.webp?blur&w=20';
 import Abhirami from '../assets/abhirami_p.webp';
-import AbhiramiBlur from '../assets/abhirami_p.webp?blur&w=20';
 import Devadarsana from '../assets/devadarsana.webp?v=3';
-import DevadarsanaBlur from '../assets/devadarsana.webp?blur&w=20&v=3';
 import Gopakumar from '../assets/gopakumar.webp';
-import GopakumarBlur from '../assets/gopakumar.webp?blur&w=20';
 
 export const cardData = [
-  { name: 'Aleetta Mariya Sebastian', img: Aleetta, blur: AleettaBlur, role: 'Chairperson' },
-  { name: 'Lisha Jins', img: Lisha, blur: LishaBlur, role: 'Vice Chairperson' },
-  { name: 'Steve Jose', img: Steve, blur: SteveBlur, role: 'Secretary' },
-  { name: 'Anna Rachel Mathew', img: AnnaRachel, blur: AnnaRachelBlur, role: 'Joint Secretary' },
-  { name: 'Amanul Farhan K S', img: Amanul, blur: AmanulBlur, role: 'Treasurer' },
-  { name: 'Abel S Mathew', img: Abel, blur: AbelBlur, role: 'Research & Development Lead' },
-  { name: 'Saniya K Shibu', img: Saniya, blur: SaniyaBlur, role: 'Program Outreach Coordinator' },
-  { name: 'Sebin Mathew', img: Sebin, blur: SebinBlur, role: 'Project Coordinator' },
-  { name: 'Anjitha Aravind', img: Anjitha, blur: AnjithaBlur, role: 'Operations Lead' },
-  { name: 'Abhirami P', img: Abhirami, blur: AbhiramiBlur, role: 'Design Lead' },
+  { name: 'Aleetta Mariya Sebastian', img: Aleetta, role: 'Chairperson' },
+  { name: 'Lisha Jins', img: Lisha, role: 'Vice Chairperson' },
+  { name: 'Steve Jose', img: Steve, role: 'Secretary' },
+  { name: 'Anna Rachel Mathew', img: AnnaRachel, role: 'Joint Secretary' },
+  { name: 'Amanul Farhan K S', img: Amanul, role: 'Treasurer' },
+  { name: 'Abel S Mathew', img: Abel, role: 'Research & Development Lead' },
+  { name: 'Saniya K Shibu', img: Saniya, role: 'Program Outreach Coordinator' },
+  { name: 'Sebin Mathew', img: Sebin, role: 'Project Coordinator' },
+  { name: 'Anjitha Aravind', img: Anjitha, role: 'Operations Lead' },
+  { name: 'Abhirami P', img: Abhirami, role: 'Design Lead' },
   {
     name: 'Devadarsana R',
     img: Devadarsana,
-    blur: DevadarsanaBlur,
     role: 'Public Relations Lead',
   },
 ];
@@ -52,6 +39,5 @@ export const cubeSlides = [...cardData, ...cardData, ...cardData];
 export const advisor = {
   name: 'Gopakumar G',
   img: Gopakumar,
-  blur: GopakumarBlur,
   role: 'Advisor',
 };

--- a/src/utils/eventPhotos.js
+++ b/src/utils/eventPhotos.js
@@ -20,9 +20,10 @@ export function photoTriplet(full, s800, s400, blur) {
       [s800, 800],
       [s400, 400],
     ]),
-    // Nullish check (not truthiness): an explicitly supplied invalid value
-    // (e.g. '') must survive into the photo object so validateEvents can
-    // flag it instead of silently treating the photo as blur-less.
-    ...(blur == null ? {} : { blur }),
+    // Only an omitted blur (undefined) is dropped. Anything explicitly
+    // supplied — including null, '', false, 0 — survives into the photo
+    // object so validateEvents can flag it as invalid instead of silently
+    // treating the photo as blur-less.
+    ...(blur === undefined ? {} : { blur }),
   };
 }

--- a/src/utils/eventPhotos.js
+++ b/src/utils/eventPhotos.js
@@ -20,6 +20,9 @@ export function photoTriplet(full, s800, s400, blur) {
       [s800, 800],
       [s400, 400],
     ]),
-    ...(blur ? { blur } : {}),
+    // Nullish check (not truthiness): an explicitly supplied invalid value
+    // (e.g. '') must survive into the photo object so validateEvents can
+    // flag it instead of silently treating the photo as blur-less.
+    ...(blur == null ? {} : { blur }),
   };
 }

--- a/src/utils/eventPhotos.js
+++ b/src/utils/eventPhotos.js
@@ -1,17 +1,18 @@
 import { srcset } from './srcset.js';
 
 /**
- * An event photo is a single { url, srcset } pair — `url` for `<img src>`,
- * `srcset` for the responsive candidates. Pairing them in one object makes
- * the old images[i] ↔ imageSets[i] parallel-array bug class structurally
- * impossible (they were unpaired arrays; EventCard did positional index math).
+ * An event photo is a single { url, srcset, blur? } object — `url` for
+ * `<img src>`, `srcset` for the responsive candidates, and an optional `blur`
+ * LQIP for the blur-up placeholder. Pairing them in one object makes the old
+ * images[i] ↔ imageSets[i] parallel-array bug class structurally impossible
+ * (they were unpaired arrays; EventCard did positional index math).
  *
  * photoTriplet builds the standard {full 1000w, -800 800w, -400 400w} srcset
  * used across events.js. The width-accuracy rule (never declare a file wider
  * than its intrinsic size; never repeat a URL at two widths) lives in
  * validateEvents, which reads these same objects.
  */
-export function photoTriplet(full, s800, s400) {
+export function photoTriplet(full, s800, s400, blur) {
   return {
     url: full,
     srcset: srcset([
@@ -19,5 +20,6 @@ export function photoTriplet(full, s800, s400) {
       [s800, 800],
       [s400, 400],
     ]),
+    ...(blur ? { blur } : {}),
   };
 }

--- a/src/utils/validateEchoSlides.js
+++ b/src/utils/validateEchoSlides.js
@@ -11,7 +11,7 @@ import { isNonEmptyString, checkUniqueKey } from './validationRules.js';
  * webp files exist is enforced by the bundler (a missing import fails the
  * build); the srcset width rules are owned by the srcset module.
  *
- * @param {Array<{image: string, imageSet: string, alt: string}>} slides
+ * @param {Array<{image: string, imageSet: string, blur: string, alt: string}>} slides
  * @returns {string[]}
  */
 export function validateEchoSlides(slides) {
@@ -33,6 +33,12 @@ export function validateEchoSlides(slides) {
 
     if (!isNonEmptyString(slide.imageSet)) {
       problems.push(`${label}: missing imageSet`);
+    }
+
+    // Blur placeholder is required (blur-up lazy loading, like the Execom
+    // cards) — a slide without one silently falls back to a plain load.
+    if (!isNonEmptyString(slide.blur)) {
+      problems.push(`${label}: missing blur`);
     }
   });
 

--- a/src/utils/validateEvents.js
+++ b/src/utils/validateEvents.js
@@ -68,14 +68,20 @@ export function validateEvents(events) {
           photo &&
           typeof photo === 'object' &&
           isNonEmptyString(photo.url) &&
-          isNonEmptyString(photo.srcset) &&
-          (photo.blur == null || isNonEmptyString(photo.blur)),
+          isNonEmptyString(photo.srcset),
       );
 
     if (!photosValid) {
       problems.push(`${label}: photos must be a non-empty array of { url, srcset }`);
     } else {
-      event.photos.forEach((photo) => {
+      event.photos.forEach((photo, photoIndex) => {
+        // Dedicated diagnostic (not folded into the generic photos error) so
+        // a bad blur is reported as what it is.
+        if (photo.blur != null && !isNonEmptyString(photo.blur)) {
+          problems.push(
+            `${label}: photo #${photoIndex + 1} blur must be a non-empty string when present`,
+          );
+        }
         const dup = findDuplicateWidth(photo.srcset);
         if (dup) {
           problems.push(`${label}: photo "${dup[0]}" declared at both ${dup[1]}w and ${dup[2]}w`);

--- a/src/utils/validateEvents.js
+++ b/src/utils/validateEvents.js
@@ -76,8 +76,10 @@ export function validateEvents(events) {
     } else {
       event.photos.forEach((photo, photoIndex) => {
         // Dedicated diagnostic (not folded into the generic photos error) so
-        // a bad blur is reported as what it is.
-        if (photo.blur != null && !isNonEmptyString(photo.blur)) {
+        // a bad blur is reported as what it is. Own-property check: an
+        // explicit null is a supplied-but-invalid value and must be rejected;
+        // an omitted blur stays valid.
+        if (Object.hasOwn(photo, 'blur') && !isNonEmptyString(photo.blur)) {
           problems.push(
             `${label}: photo #${photoIndex + 1} blur must be a non-empty string when present`,
           );

--- a/src/utils/validateEvents.js
+++ b/src/utils/validateEvents.js
@@ -56,8 +56,10 @@ export function validateEvents(events) {
       problems.push(`${label}: websiteUrl must be a non-empty string when present`);
     }
 
-    // photos are { url, srcset } pairs (src/utils/eventPhotos.js) — the pairing
-    // is structural, so no parity check is needed; only shape + width accuracy.
+    // photos are { url, srcset, blur? } objects (src/utils/eventPhotos.js) —
+    // the pairing is structural, so no parity check is needed; only shape +
+    // width accuracy. `blur` is optional (only the first event's primary
+    // carries an LQIP) but must be a non-empty string when present.
     const photosValid =
       Array.isArray(event.photos) &&
       event.photos.length > 0 &&
@@ -66,7 +68,8 @@ export function validateEvents(events) {
           photo &&
           typeof photo === 'object' &&
           isNonEmptyString(photo.url) &&
-          isNonEmptyString(photo.srcset),
+          isNonEmptyString(photo.srcset) &&
+          (photo.blur == null || isNonEmptyString(photo.blur)),
       );
 
     if (!photosValid) {

--- a/src/utils/validateTeam.js
+++ b/src/utils/validateTeam.js
@@ -9,7 +9,7 @@ import { isNonEmptyString, checkUniqueKey } from './validationRules.js';
  * validateEvents.js: shape only. Whether the referenced webp files exist is
  * enforced by the bundler (a missing import fails the build).
  *
- * @param {Array<{name: string, img: string, role: string}>} members
+ * @param {Array<{name: string, img: string, blur?: string, role: string}>} members
  * @returns {string[]}
  */
 export function validateTeam(members) {
@@ -31,6 +31,12 @@ export function validateTeam(members) {
 
     if (!isNonEmptyString(member.img)) {
       problems.push(`${label}: missing img`);
+    }
+
+    // `blur` is optional (only the lead images carry an LQIP) but must be a
+    // non-empty string when present.
+    if (member.blur != null && !isNonEmptyString(member.blur)) {
+      problems.push(`${label}: blur must be a non-empty string when present`);
     }
   });
 

--- a/src/utils/validateTeam.js
+++ b/src/utils/validateTeam.js
@@ -34,8 +34,10 @@ export function validateTeam(members) {
     }
 
     // `blur` is optional (only the lead images carry an LQIP) but must be a
-    // non-empty string when present.
-    if (member.blur != null && !isNonEmptyString(member.blur)) {
+    // non-empty string when present. Own-property check (not `!= null`): an
+    // explicit null is a supplied-but-invalid value and must be rejected,
+    // while an omitted blur stays valid.
+    if ('blur' in member && !isNonEmptyString(member.blur)) {
       problems.push(`${label}: blur must be a non-empty string when present`);
     }
   });

--- a/src/utils/validateTeam.js
+++ b/src/utils/validateTeam.js
@@ -9,7 +9,7 @@ import { isNonEmptyString, checkUniqueKey } from './validationRules.js';
  * validateEvents.js: shape only. Whether the referenced webp files exist is
  * enforced by the bundler (a missing import fails the build).
  *
- * @param {Array<{name: string, img: string, blur: string, role: string}>} members
+ * @param {Array<{name: string, img: string, role: string}>} members
  * @returns {string[]}
  */
 export function validateTeam(members) {
@@ -31,10 +31,6 @@ export function validateTeam(members) {
 
     if (!isNonEmptyString(member.img)) {
       problems.push(`${label}: missing img`);
-    }
-
-    if (!isNonEmptyString(member.blur)) {
-      problems.push(`${label}: missing blur`);
     }
   });
 

--- a/src/utils/validateTeam.js
+++ b/src/utils/validateTeam.js
@@ -34,10 +34,11 @@ export function validateTeam(members) {
     }
 
     // `blur` is optional (only the lead images carry an LQIP) but must be a
-    // non-empty string when present. Own-property check (not `!= null`): an
-    // explicit null is a supplied-but-invalid value and must be rejected,
-    // while an omitted blur stays valid.
-    if ('blur' in member && !isNonEmptyString(member.blur)) {
+    // non-empty string when present. Own-property check (not `in`, which also
+    // sees inherited properties, and not `!= null`, which lets explicit null
+    // slip through): an explicit null is a supplied-but-invalid value and
+    // must be rejected, while an omitted blur stays valid.
+    if (Object.prototype.hasOwnProperty.call(member, 'blur') && !isNonEmptyString(member.blur)) {
       problems.push(`${label}: blur must be a non-empty string when present`);
     }
   });

--- a/tests/unit/echoSlides.spec.js
+++ b/tests/unit/echoSlides.spec.js
@@ -10,6 +10,7 @@ describe('validateEchoSlides — shape rules', () => {
   const slide = (overrides = {}) => ({
     image: '/episode.webp',
     imageSet: '/episode.webp 1280w, /episode-960.webp 960w',
+    blur: '/episode-blur.webp',
     alt: 'ECHO - Episode 1',
     ...overrides,
   });
@@ -31,6 +32,11 @@ describe('validateEchoSlides — shape rules', () => {
   it('flags a missing imageSet (srcset)', () => {
     const problems = validateEchoSlides([slide({ imageSet: '' })]);
     expect(problems.join('\n')).toContain('missing imageSet');
+  });
+
+  it('flags a missing blur placeholder', () => {
+    const problems = validateEchoSlides([slide({ blur: '' })]);
+    expect(problems.join('\n')).toContain('missing blur');
   });
 
   it('flags duplicate alts', () => {

--- a/tests/unit/echoSlides.spec.js
+++ b/tests/unit/echoSlides.spec.js
@@ -34,8 +34,15 @@ describe('validateEchoSlides — shape rules', () => {
     expect(problems.join('\n')).toContain('missing imageSet');
   });
 
-  it('flags a missing blur placeholder', () => {
+  it('flags an empty blur placeholder', () => {
     const problems = validateEchoSlides([slide({ blur: '' })]);
+    expect(problems.join('\n')).toContain('missing blur');
+  });
+
+  it('flags a slide with the blur field omitted entirely', () => {
+    const { blur, ...noBlur } = slide();
+    expect(blur).toBeTruthy(); // guard: the factory still carries one
+    const problems = validateEchoSlides([noBlur]);
     expect(problems.join('\n')).toContain('missing blur');
   });
 

--- a/tests/unit/eventPhotos.spec.js
+++ b/tests/unit/eventPhotos.spec.js
@@ -9,4 +9,19 @@ describe('photoTriplet', () => {
       srcset: '/assets/p.webp 1000w, /assets/p-800.webp 800w, /assets/p-400.webp 400w',
     });
   });
+
+  it('omits blur entirely when not supplied', () => {
+    const photo = photoTriplet('/assets/p.webp', '/assets/p-800.webp', '/assets/p-400.webp');
+    expect(Object.hasOwn(photo, 'blur')).toBe(false);
+  });
+
+  it('preserves an explicitly supplied null blur for validation', () => {
+    const photo = photoTriplet('/assets/p.webp', '/assets/p-800.webp', '/assets/p-400.webp', null);
+    expect(photo.blur).toBe(null);
+  });
+
+  it('preserves an explicitly supplied empty blur for validation', () => {
+    const photo = photoTriplet('/assets/p.webp', '/assets/p-800.webp', '/assets/p-400.webp', '');
+    expect(photo.blur).toBe('');
+  });
 });

--- a/tests/unit/eventsData.spec.js
+++ b/tests/unit/eventsData.spec.js
@@ -15,3 +15,33 @@ describe('featuredEvents data integrity', () => {
     expect(featuredEvents.length).toBeGreaterThan(0);
   });
 });
+
+describe('validateEvents — optional photo blur', () => {
+  const photo = (overrides = {}) => ({
+    url: '/poster.webp',
+    srcset: '/poster.webp 1000w, /poster-800.webp 800w',
+    ...overrides,
+  });
+
+  const event = (photos) => ({
+    id: 1,
+    name: 'Test Event',
+    tag: 'Tag',
+    date: '1st Jan 2026',
+    desc: 'Description',
+    photos,
+  });
+
+  it('accepts photos without a blur (plain lazy load)', () => {
+    expect(validateEvents([event([photo()])])).toEqual([]);
+  });
+
+  it('accepts a photo with a blur LQIP', () => {
+    expect(validateEvents([event([photo({ blur: '/poster-blur.webp' })])])).toEqual([]);
+  });
+
+  it('flags a photo whose blur is present but empty', () => {
+    const problems = validateEvents([event([photo({ blur: '' })])]);
+    expect(problems.join('\n')).toContain('photos must be a non-empty array of { url, srcset }');
+  });
+});

--- a/tests/unit/eventsData.spec.js
+++ b/tests/unit/eventsData.spec.js
@@ -53,4 +53,9 @@ describe('validateEvents — optional photo blur', () => {
     const problems = validateEvents([event([photo({ blur: '' })])]);
     expect(problems.join('\n')).toContain('blur must be a non-empty string when present');
   });
+
+  it('rejects an explicit photo blur: null (supplied but invalid)', () => {
+    const problems = validateEvents([event([photo({ blur: null })])]);
+    expect(problems.join('\n')).toContain('blur must be a non-empty string when present');
+  });
 });

--- a/tests/unit/eventsData.spec.js
+++ b/tests/unit/eventsData.spec.js
@@ -14,6 +14,15 @@ describe('featuredEvents data integrity', () => {
   it('has at least one event', () => {
     expect(featuredEvents.length).toBeGreaterThan(0);
   });
+
+  it('first event primary photo carries the blur LQIP', () => {
+    // Production wiring guard: the home Events banner and the /events first
+    // card both read photos[0].blur — if the field ever stops being wired
+    // to an LQIP, this fails.
+    const blur = featuredEvents[0].photos[0].blur;
+    expect(typeof blur).toBe('string');
+    expect(blur.length).toBeGreaterThan(0);
+  });
 });
 
 describe('validateEvents — optional photo blur', () => {
@@ -42,6 +51,6 @@ describe('validateEvents — optional photo blur', () => {
 
   it('flags a photo whose blur is present but empty', () => {
     const problems = validateEvents([event([photo({ blur: '' })])]);
-    expect(problems.join('\n')).toContain('photos must be a non-empty array of { url, srcset }');
+    expect(problems.join('\n')).toContain('blur must be a non-empty string when present');
   });
 });

--- a/tests/unit/teamData.spec.js
+++ b/tests/unit/teamData.spec.js
@@ -32,6 +32,16 @@ describe('validateTeam — shape rules', () => {
     const problems = validateTeam([member, { ...member, role: 'Other' }]);
     expect(problems.join('\n')).toContain('duplicate name');
   });
+
+  it('accepts an optional blur LQIP on lead images', () => {
+    const member = { name: 'A Member', img: '/a.webp', blur: '/a-blur.webp', role: 'Lead' };
+    expect(validateTeam([member])).toEqual([]);
+  });
+
+  it('flags a blur that is present but empty', () => {
+    const member = { name: 'A Member', img: '/a.webp', blur: '', role: 'Lead' };
+    expect(validateTeam([member]).join('\n')).toContain('blur must be a non-empty string');
+  });
 });
 
 describe('teamData integrity (src/data/team.js)', () => {

--- a/tests/unit/teamData.spec.js
+++ b/tests/unit/teamData.spec.js
@@ -4,38 +4,33 @@ import { validateTeam } from '../../src/utils/validateTeam.js';
 
 // Guard for the live team roster (src/data/team.js). Runs in CI via
 // `pnpm test:unit`, so a malformed entry — duplicate name, missing role, or
-// a missing img/blur pairing — fails the build. Mirrors eventsData.spec.js.
+// a missing img — fails the build. Mirrors eventsData.spec.js.
 
 describe('validateTeam — shape rules', () => {
   it('accepts a well-formed member', () => {
-    const member = { name: 'A Member', img: '/a.webp', blur: '/a-blur.webp', role: 'Lead' };
+    const member = { name: 'A Member', img: '/a.webp', role: 'Lead' };
     expect(validateTeam([member])).toEqual([]);
   });
 
   it('flags a missing role', () => {
-    const member = { name: 'A Member', img: '/a.webp', blur: '/a-blur.webp' };
+    const member = { name: 'A Member', img: '/a.webp' };
     expect(validateTeam([member]).join('\n')).toContain('missing role');
   });
 
   it('flags a missing name', () => {
-    const member = { img: '/a.webp', blur: '/a-blur.webp', role: 'Lead' };
+    const member = { img: '/a.webp', role: 'Lead' };
     expect(validateTeam([member]).join('\n')).toContain('missing name');
   });
 
   it('flags a missing img', () => {
-    const member = { name: 'A Member', blur: '/a-blur.webp', role: 'Lead' };
+    const member = { name: 'A Member', role: 'Lead' };
     expect(validateTeam([member]).join('\n')).toContain('missing img');
   });
 
   it('flags duplicate names', () => {
-    const member = { name: 'A Member', img: '/a.webp', blur: '/a-blur.webp', role: 'Lead' };
+    const member = { name: 'A Member', img: '/a.webp', role: 'Lead' };
     const problems = validateTeam([member, { ...member, role: 'Other' }]);
     expect(problems.join('\n')).toContain('duplicate name');
-  });
-
-  it('flags a missing img/blur pairing', () => {
-    const member = { name: 'A Member', img: '/a.webp', role: 'Lead' };
-    expect(validateTeam([member]).join('\n')).toContain('missing blur');
   });
 });
 

--- a/tests/unit/teamData.spec.js
+++ b/tests/unit/teamData.spec.js
@@ -47,6 +47,17 @@ describe('validateTeam — shape rules', () => {
     const member = { name: 'A Member', img: '/a.webp', blur: null, role: 'Lead' };
     expect(validateTeam([member]).join('\n')).toContain('blur must be a non-empty string');
   });
+
+  it('ignores a blur inherited through the prototype (not an own property)', () => {
+    // Regression: `'blur' in member` would validate an inherited blur and
+    // reject an invalid one that the member never supplied. Only own
+    // properties count.
+    const member = Object.create({ blur: '' });
+    member.name = 'A Member';
+    member.img = '/a.webp';
+    member.role = 'Lead';
+    expect(validateTeam([member])).toEqual([]);
+  });
 });
 
 describe('teamData integrity (src/data/team.js)', () => {

--- a/tests/unit/teamData.spec.js
+++ b/tests/unit/teamData.spec.js
@@ -42,6 +42,11 @@ describe('validateTeam — shape rules', () => {
     const member = { name: 'A Member', img: '/a.webp', blur: '', role: 'Lead' };
     expect(validateTeam([member]).join('\n')).toContain('blur must be a non-empty string');
   });
+
+  it('rejects an explicit blur: null (supplied but invalid)', () => {
+    const member = { name: 'A Member', img: '/a.webp', blur: null, role: 'Lead' };
+    expect(validateTeam([member]).join('\n')).toContain('blur must be a non-empty string');
+  });
 });
 
 describe('teamData integrity (src/data/team.js)', () => {


### PR DESCRIPTION
## Summary

Three commits landing the blur-up lazy-loading work plus the loader logo:

1. **feat(perf): blur-up lazy loading for featuring and first events image**
   - Featuring carousel + events first-card poster now lazy-load through `BlurImage` with LQIP placeholders (w=128 — verified to preserve real structure under the 20px CSS blur vs the w=20 flat wash).
   - Dropped the 12 Execom/team LQIPs (17 → 5 blurry images, −12 HTTP round-trips for ~200 B each — worst placeholder ROI).
   - `data-aos` moved off the featuring `<img>` onto a wrapper so AOS's `[data-aos]` opacity rules can't defeat the cross-fade.
2. **feat: add FOCES logo to the coffee mug loader** — black wordmark centered on the white mug face, above the coffee bars, sized so the cup stays visible; decorative (aria-hidden + eager/async).
3. **feat: blur-up lead images for home events and execom advisor** — every home-page section's lead image now blur-ups like Featuring: home Events first banner + Execom advisor portrait (w=128); other cards stay plain lazy loads.

## Verification

- Unit: 469 passed · E2E (Playwright, chromium + mobile): **79 passed, 0 failed** (13 expected skips) · build ✅ · lint/format/check-assets/check-specs ✅
- Blur files in `dist/assets`: exactly 6 (4 featuring + events poster + advisor), each 1.4–1.8 KB
- Visual verification in-browser: blur placeholder shows → 500ms cross-fade → placeholder removed (screenshots in `test-results/`)

## Notes for reviewers

- LQIP count intentionally small (6) with high detail (w=128) — fewer, better placeholders over many tiny ones.
- Hero stays a preloaded LCP (no blur); AboutUs is a logo SVG (no blur).