### PR TITLE
perf: gate hero WebGL on 3g + ship only the used AOS CSS subset

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,9 @@
 import './App.css';
-import 'aos/dist/aos.css';
+// Minimal AOS stylesheet — the full aos/dist/aos.css (~26KB) enumerates every
+// duration/easing variant; this site uses 5 animations × 4 durations. The
+// subset is guarded by tests/unit/aosCss.spec.js (any new data-aos value must
+// extend src/assets/aos-min.css in the same change).
+import './assets/aos-min.css';
 import { Suspense, useEffect } from 'react';
 import SectionSkeleton from './Components/SectionSkeleton/SectionSkeleton';
 import ScrollGate from './Components/ScrollGate/ScrollGate';

--- a/src/assets/aos-min.css
+++ b/src/assets/aos-min.css
@@ -9,7 +9,8 @@
  *   durations:  300, 750, 1000 explicitly; 400 is the AOS default (no
  *               data-aos-duration attribute → body[data-aos-duration="400"]).
  *
- * Rules below are copied verbatim from aos/dist/aos.css (v3). The guard in
+ * Rules below are copied verbatim from aos/dist/aos.css (the v2.3.4 the
+ * project pins). The guard in
  * tests/unit/aosCss.spec.js scans src/ for data-aos attribute values and
  * fails if any new value falls outside this subset — so adding a new
  * animation/duration requires extending this file in the same change.

--- a/src/assets/aos-min.css
+++ b/src/assets/aos-min.css
@@ -1,0 +1,84 @@
+/*
+ * Minimal AOS stylesheet — hand-picked subset of aos/dist/aos.css.
+ *
+ * The full AOS stylesheet (~26 KB) enumerates every duration (50→3000ms),
+ * easing, and animation variant so users can pick any combination at runtime.
+ * This site uses only 5 animations × 4 durations, no easings, no delays:
+ *
+ *   animations: flip-up (×7), fade-up (×3), zoom-in (×1), flip-right (×1), fade-down (×1)
+ *   durations:  300, 750, 1000 explicitly; 400 is the AOS default (no
+ *               data-aos-duration attribute → body[data-aos-duration="400"]).
+ *
+ * Rules below are copied verbatim from aos/dist/aos.css (v3). The guard in
+ * tests/unit/aosCss.spec.js scans src/ for data-aos attribute values and
+ * fails if any new value falls outside this subset — so adding a new
+ * animation/duration requires extending this file in the same change.
+ *
+ * The safety nets live in App.css (body.aos-disabled / prefers-reduced-motion
+ * force-shows); AOS's own JS (aos/dist/aos.js) still drives .aos-animate.
+ */
+
+/* ---- flip ---- */
+[data-aos^='flip'][data-aos^='flip'] {
+    backface-visibility: hidden;
+    transition-property: transform;
+}
+[data-aos='flip-up'] {
+    transform: perspective(2500px) rotateX(-100deg);
+}
+[data-aos='flip-up'].aos-animate {
+    transform: perspective(2500px) rotateX(0);
+}
+[data-aos='flip-right'] {
+    transform: perspective(2500px) rotateY(100deg);
+}
+[data-aos='flip-right'].aos-animate {
+    transform: perspective(2500px) rotateY(0);
+}
+
+/* ---- fade ---- */
+[data-aos^='fade'][data-aos^='fade'] {
+    opacity: 0;
+    transition-property: opacity, transform;
+}
+[data-aos^='fade'][data-aos^='fade'].aos-animate {
+    opacity: 1;
+    transform: translateZ(0);
+}
+[data-aos='fade-up'] {
+    transform: translate3d(0, 100px, 0);
+}
+[data-aos='fade-down'] {
+    transform: translate3d(0, -100px, 0);
+}
+
+/* ---- zoom ---- */
+[data-aos^='zoom'][data-aos^='zoom'] {
+    opacity: 0;
+    transition-property: opacity, transform;
+}
+[data-aos^='zoom'][data-aos^='zoom'].aos-animate {
+    opacity: 1;
+    transform: translateZ(0) scale(1);
+}
+[data-aos='zoom-in'] {
+    transform: scale(0.6);
+}
+
+/* ---- durations (300 / 400 default / 750 / 1000) ---- */
+[data-aos][data-aos][data-aos-duration='300'],
+body[data-aos-duration='300'] [data-aos] {
+    transition-duration: 0.3s;
+}
+[data-aos][data-aos][data-aos-duration='400'],
+body[data-aos-duration='400'] [data-aos] {
+    transition-duration: 0.4s;
+}
+[data-aos][data-aos][data-aos-duration='750'],
+body[data-aos-duration='750'] [data-aos] {
+    transition-duration: 0.75s;
+}
+[data-aos][data-aos][data-aos-duration='1000'],
+body[data-aos-duration='1000'] [data-aos] {
+    transition-duration: 1s;
+}

--- a/src/utils/detectProfile.js
+++ b/src/utils/detectProfile.js
@@ -70,7 +70,11 @@ function detectNetwork() {
     if (conn.saveData) return true;
 
     const type = (conn.effectiveType || '').toLowerCase();
-    if (type === 'slow-2g' || type === '2g') return true;
+    // '3g' counts as slow: the browser only reports it for genuinely degraded
+    // connections (RTT > ~270ms or downlink < ~2.5 Mbps) — not just slow-2g/2g.
+    // A desktop on Fast 3G otherwise still downloads the 724KB three.js chunk
+    // and fires route prefetches (measured via ?perf=slow: identical profile).
+    if (type === 'slow-2g' || type === '2g' || type === '3g') return true;
 
     if (typeof conn.downlink === 'number' && conn.downlink > 0 && conn.downlink < 1.2) return true;
   } catch {

--- a/src/utils/detectProfile.js
+++ b/src/utils/detectProfile.js
@@ -70,10 +70,10 @@ function detectNetwork() {
     if (conn.saveData) return true;
 
     const type = (conn.effectiveType || '').toLowerCase();
-    // '3g' counts as slow: the browser only reports it for genuinely degraded
-    // connections (RTT > ~270ms or downlink < ~2.5 Mbps) — not just slow-2g/2g.
-    // A desktop on Fast 3G otherwise still downloads the 724KB three.js chunk
-    // and fires route prefetches (measured via ?perf=slow: identical profile).
+    // '3g' counts as slow: it is an application performance-policy decision
+    // (the UA only reports it for genuinely degraded connections — a desktop
+    // on Fast 3G would otherwise still download the 724KB three.js chunk and
+    // fire route prefetches; measured via ?perf=slow: identical profile).
     if (type === 'slow-2g' || type === '2g' || type === '3g') return true;
 
     if (typeof conn.downlink === 'number' && conn.downlink > 0 && conn.downlink < 1.2) return true;

--- a/tests/unit/aosCss.spec.js
+++ b/tests/unit/aosCss.spec.js
@@ -1,0 +1,90 @@
+/* global process -- tests execute in node (vitest), only browser/vitest globals are declared */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+/**
+ * Guard for src/assets/aos-min.css — the hand-picked subset of the AOS
+ * stylesheet. AOS CSS hides [data-aos] elements (opacity/transform) until
+ * .aos-animate is added, so any data-aos value the CSS doesn't cover leaves
+ * that element permanently invisible. This spec scans every source file for
+ * data-aos attribute values and fails when a value falls outside the subset —
+ * adding a new animation/duration must extend aos-min.css in the same change.
+ */
+
+const SUPPORTED_ANIMATIONS = ['flip-up', 'flip-right', 'fade-up', 'fade-down', 'zoom-in'];
+// 400 is the AOS init default: elements without an explicit data-aos-duration
+// match body[data-aos-duration="400"] (AOS writes the default onto <body>).
+const SUPPORTED_DURATIONS = [300, 400, 750, 1000];
+
+// Tests run from the repo root (vitest cwd); resolve src/ relative to it.
+const srcRoot = resolve(process.cwd(), 'src');
+
+function walk(dir) {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) return walk(full);
+    return /\.(jsx|js)$/.test(entry) && !full.includes('foces-webv23') ? [full] : [];
+  });
+}
+
+const sourceFiles = walk(srcRoot);
+const sources = sourceFiles
+  .map((f) => readFileSync(f, 'utf8'))
+  .filter((text) => text.includes('data-aos'));
+
+const used = {
+  animations: new Set(),
+  durations: new Set(),
+  easings: new Set(),
+  delays: new Set(),
+};
+
+for (const text of sources) {
+  for (const attr of ['data-aos', 'data-aos-duration', 'data-aos-easing', 'data-aos-delay']) {
+    const re = new RegExp(`${attr}="([^"]*)"`, 'g');
+    for (const match of text.matchAll(re)) {
+      const value = match[1];
+      if (attr === 'data-aos') used.animations.add(value);
+      else if (attr === 'data-aos-duration') used.durations.add(value);
+      else if (attr === 'data-aos-easing') used.easings.add(value);
+      else used.delays.add(value);
+    }
+  }
+}
+
+describe('aos-min.css — every used data-aos value is covered', () => {
+  it('the scan found [data-aos] usage (guard is not vacuously passing)', () => {
+    expect(used.animations.size).toBeGreaterThan(0);
+    expect(sourceFiles.length).toBeGreaterThan(0);
+  });
+
+  it('every used animation is in the minimal stylesheet', () => {
+    const missing = [...used.animations].filter((a) => !SUPPORTED_ANIMATIONS.includes(a));
+    expect(missing).toEqual([]);
+  });
+
+  it('every used duration is in the minimal stylesheet (plus the 400 default)', () => {
+    const missing = [...used.durations].filter((d) => !SUPPORTED_DURATIONS.map(String).includes(d));
+    expect(missing).toEqual([]);
+  });
+
+  it('no easings or delays are used (the subset ships none)', () => {
+    expect([...used.easings]).toEqual([]);
+    expect([...used.delays]).toEqual([]);
+  });
+
+  it('the stylesheet actually contains a rule for each supported animation', () => {
+    const css = readFileSync(resolve(process.cwd(), 'src/assets/aos-min.css'), 'utf8');
+    for (const animation of SUPPORTED_ANIMATIONS) {
+      expect(css).toContain(`[data-aos='${animation}']`);
+    }
+  });
+
+  it('the stylesheet actually contains a duration rule for each supported duration', () => {
+    const css = readFileSync(resolve(process.cwd(), 'src/assets/aos-min.css'), 'utf8');
+    for (const duration of SUPPORTED_DURATIONS) {
+      expect(css).toContain(`data-aos-duration='${duration}'`);
+    }
+  });
+});

--- a/tests/unit/aosCss.spec.js
+++ b/tests/unit/aosCss.spec.js
@@ -42,9 +42,11 @@ const used = {
 
 for (const text of sources) {
   for (const attr of ['data-aos', 'data-aos-duration', 'data-aos-easing', 'data-aos-delay']) {
-    const re = new RegExp(`${attr}="([^"]*)"`, 'g');
+    // Match both single- and double-quoted JSX attributes; group 1 captures the
+    // quote so group 2 is always the attribute value.
+    const re = new RegExp(`${attr}\\s*=\\s*(['"])([^'"]*)\\1`, 'g');
     for (const match of text.matchAll(re)) {
-      const value = match[1];
+      const value = match[2];
       if (attr === 'data-aos') used.animations.add(value);
       else if (attr === 'data-aos-duration') used.durations.add(value);
       else if (attr === 'data-aos-easing') used.easings.add(value);

--- a/tests/unit/detectProfile.spec.js
+++ b/tests/unit/detectProfile.spec.js
@@ -126,9 +126,10 @@ describe('detectProfile — network heuristics', () => {
   });
 
   it('a 3g effective type marks the profile slow even at high downlink', () => {
-    // The browser only reports '3g' for degraded connections (RTT/downlink
-    // thresholds), so the effective type alone is the slow signal — a desktop
-    // on Fast 3G would otherwise still pull the 724KB three.js chunk.
+    // Treating '3g' as slow is an application performance-policy decision — the
+    // UA reports it only for degraded connections, so the effective type alone
+    // is the slow signal, regardless of the reported downlink. A desktop on
+    // Fast 3G would otherwise still pull the 724KB three.js chunk.
     stubNavigator({ connection: { saveData: false, effectiveType: '3g', downlink: 20 } });
     expect(detectProfile().slowNetwork).toBe(true);
     expect(detectProfile().lowPower).toBe(true);

--- a/tests/unit/detectProfile.spec.js
+++ b/tests/unit/detectProfile.spec.js
@@ -125,6 +125,15 @@ describe('detectProfile — network heuristics', () => {
     expect(detectProfile().slowNetwork).toBe(true);
   });
 
+  it('a 3g effective type marks the profile slow even at high downlink', () => {
+    // The browser only reports '3g' for degraded connections (RTT/downlink
+    // thresholds), so the effective type alone is the slow signal — a desktop
+    // on Fast 3G would otherwise still pull the 724KB three.js chunk.
+    stubNavigator({ connection: { saveData: false, effectiveType: '3g', downlink: 20 } });
+    expect(detectProfile().slowNetwork).toBe(true);
+    expect(detectProfile().lowPower).toBe(true);
+  });
+
   it('a low downlink (< 1.2 Mbps) marks the profile slow', () => {
     stubNavigator({ connection: { saveData: false, effectiveType: '3g', downlink: 1.0 } });
     expect(detectProfile().slowNetwork).toBe(true);


### PR DESCRIPTION
## What

Two perf wins for low-end phones / 3G (from the bandwidth audit — top offenders were the 724 KB three.js chunk and the 86 KB eager CSS):

**1. `3g` effectiveType now counts as slow network** (`detectProfile.js`)
Chrome reports `3g` only for genuinely degraded connections (RTT > ~270ms or < ~2.5 Mbps), but the old check caught only `2g`/`slow-2g`/saveData — so a desktop on Fast 3G still downloaded the **724 KB three.js hero chunk** and fired route prefetches. Now it resolves to the same profile as `?perf=slow`: hero WebGL skipped, no prefetch. Zero cost for anyone the browser calls `4g`.

**2. AOS stylesheet 26 KB → 1 KB** (`src/assets/aos-min.css`)
The eager `index.css` shipped the **entire AOS stylesheet** (every duration 50→3000ms × all easings). The site uses **5 animations × 4 durations, no easings, no delays**. The subset is verbatim rules from `aos/dist/aos.css` — animation behavior is byte-identical.

**3. Regression guard** (`tests/unit/aosCss.spec.js`) — fails if a new `data-aos` value falls outside the subset, so content can't silently stay invisible.

## Measured

| | Before | After |
|---|---|---|
| Eager `index.css` | 86.3 KB | **61.7 KB (−29%)** |
| Fast-3G desktop download | ~3.56 MB (incl. three.js) | **−724 KB** (three.js gated) |
| Unit tests | | 484 passed |
| E2E (home/events/carousels/accessibility) | | 51 passed, 0 failed, axe clean |
| Lint / format / check-specs / check-assets / check-sw | | ✅ |