### PR TITLE
feat(perf): replace Swiper with hand-rolled carousels + AOS failsafe

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,7 +33,6 @@ updates:
           - "prop-types"
       rendering-and-animation:
         patterns:
-          - "swiper"
           - "aos"
       dev-tooling:
         patterns:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,8 +20,8 @@ lowPower }` from `detectProfile`. One seam, two entries: components
   `detectProfile()` once. Never re-implement a heuristic or override
   elsewhere.
 - **ScrollGate** — mounts a lazy section only when it approaches the
-  viewport, so swiper-vendor never evaluates at boot. The mount decision is
-  the pure `shouldMountSection`.
+  viewport, so the carousel sections' code never evaluates at boot. The
+  mount decision is the pure `shouldMountSection`.
 - **Cube easter egg** — the About-cube rapid-spin celebration. Spin
   counting lives in the pure `createSpinTracker` (`easterEggLogic.js`):
   fires after `target` spins within `gap` ms, gap-reset so casual spinning
@@ -30,7 +30,9 @@ lowPower }` from `detectProfile`. One seam, two entries: components
   Touch-first phones get an easier bar (8/1.5s vs 20/0.8s desktop); the
   cube owns its touch gesture (`touch-action: none`) so rotating never
   scrolls the page. The same touch-ownership rule applies to the Execom
-  team carousel (`.execom-swiper` / `.execom-cube-swiper`).
+  team carousel (`.execom-swiper` / `.execom-cube-swiper`), which is
+  hand-rolled (`useCarousel` + `carouselGeometry`) — the old Swiper was
+  replaced to drop the ~104 KB vendor chunk.
 - **Team roster** — the Execom member cards. Single source of truth:
   `src/data/team.js` (`cardData`, `cubeSlides`, `advisor`), shape-guarded
   by `validateTeam` in CI. Each member has a **role** (Chairperson,

--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ open/review/merge PRs too. The checks you'll see: `Lint & Build`, `E2E
 
 - **[React 19](https://react.dev/)** + **[Vite 8](https://vite.dev/)** (SWC plugin)
 - **[Tailwind CSS](https://tailwindcss.com/)** for styling
-- **[Swiper](https://swiperjs.com/)** carousels (Featuring, event galleries, execom)
+- **Hand-rolled carousels** (`useCarousel` + `carouselGeometry.js`): the
+  Featuring flat slider and the Execom 3D cube (rotateY 90° per face) —
+  replaced Swiper to drop the ~104 KB vendor chunk
 - **[Three.js](https://threejs.org/) / [Vanta](https://www.vantajs.com/)** hero background
 - **[react-router](https://reactrouter.com/)** for `/events` and `/contact` routes
 - **PWA** ([`vite-plugin-pwa`](https://vite-pwa-org.netlify.app/)) with service-worker precaching

--- a/docs/adr/0007-touch-gesture-ownership.md
+++ b/docs/adr/0007-touch-gesture-ownership.md
@@ -14,12 +14,11 @@ claimed any vertical component of the gesture and scrolled mid-rotation
 
 Every interactive rotation/carousel widget owns its touch gesture entirely:
 `touch-action: none` on the draggable element (About cube, `.execom-swiper`,
-`.execom-cube-swiper`), plus — where the widget has no native handler — a
-non-passive `touchmove` preventDefault while dragging (React's delegated
-touchmove is passive, so `e.preventDefault()` there would no-op). Swiper
-already preventDefaults its own swipes with non-passive listeners; it only
-lacked the CSS ownership. See the code comments in `AboutUs.css`,
-`Execom/custom.css`, and `AboutUs.jsx`.
+`.execom-cube-swiper`), plus a non-passive pointermove preventDefault while
+dragging (the carousels are hand-rolled — `useCarousel` registers its
+pointer handlers non-passive, so `e.preventDefault()` works; React's
+delegated events are passive and would no-op). See the code comments in
+`AboutUs.css`, `Execom/custom.css`, and `AboutUs.jsx`.
 
 ## Consequences
 

--- a/docs/adr/0007-touch-gesture-ownership.md
+++ b/docs/adr/0007-touch-gesture-ownership.md
@@ -15,10 +15,11 @@ claimed any vertical component of the gesture and scrolled mid-rotation
 Every interactive rotation/carousel widget owns its touch gesture entirely:
 `touch-action: none` on the draggable element (About cube, `.execom-swiper`,
 `.execom-cube-swiper`), plus a non-passive pointermove preventDefault while
-dragging (the carousels are hand-rolled — `useCarousel` registers its
-pointer handlers non-passive, so `e.preventDefault()` works; React's
-delegated events are passive and would no-op). See the code comments in
-`AboutUs.css`, `Execom/custom.css`, and `AboutUs.jsx`.
+dragging — `useCarousel` registers its pointermove listener natively with
+`{ passive: false }` and calls `preventDefault()` on every move while
+dragging, so the page cannot scroll mid-gesture regardless of any event
+delegation policy. See the code comments in `AboutUs.css`,
+`Execom/custom.css`, and `AboutUs.jsx`.
 
 ## Consequences
 

--- a/knip.json
+++ b/knip.json
@@ -27,7 +27,6 @@
     "react-icons",
     "react-router",
     "react-toastify",
-    "swiper",
     "three",
     "vanta",
     "yet-another-react-lightbox",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "react-icons": "^5.7.0",
     "react-router": "8.3.0",
     "react-toastify": "^11.1.0",
-    "swiper": "14.1.0",
     "three": "^0.185.1",
     "vanta": "^0.5.24",
     "yet-another-react-lightbox": "^3.32.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,9 +56,6 @@ importers:
       react-toastify:
         specifier: ^11.1.0
         version: 11.1.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      swiper:
-        specifier: 14.1.0
-        version: 14.1.0
       three:
         specifier: ^0.185.1
         version: 0.185.1
@@ -4315,10 +4312,6 @@ packages:
     resolution: {integrity: sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==}
     engines: {node: '>=16'}
     hasBin: true
-
-  swiper@14.1.0:
-    resolution: {integrity: sha512-ppit/AqmGvThKlXy4I1/9N/gEyb9s/BDHWciWNeIxbfteFKUhPQXrYuOMKszomXKd9WiLd+/0vKdPHW+0N0mhA==}
-    engines: {node: '>= 4.7.0'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -8972,8 +8965,6 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.1
       sax: 1.6.1
-
-  swiper@14.1.0: {}
 
   symbol-tree@3.2.4: {}
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -82,8 +82,8 @@ profiler (1ms sampling during load) inflates absolute timings under throttle
 build. Use its output to answer "which chunk is costing boot CPU?"
 (per-chunk eval ms), not "how fast is the page?". For wall-clock numbers use
 `perf-test.mjs` / Lighthouse. The boot-behavioral regression it guards
-(swiper-vendor must not be fetched at boot) is enforced in CI by the E2E
-spec `tests/swiper-lazy.spec.js`, so no CI wiring is needed here.
+(the carousel sections must not mount/fetch at boot) is enforced in CI by
+the E2E spec `tests/carousel-lazy.spec.js`, so no CI wiring is needed here.
 
 ### Shared Constants
 

--- a/scripts/probes/carousel-probe.mjs
+++ b/scripts/probes/carousel-probe.mjs
@@ -25,7 +25,7 @@ await new Promise((r) => setTimeout(r, 1000));
 
 const feat = await p.evaluate(() => {
   const sec = document.getElementById('featuring');
-  const swiper = sec.querySelector('.swiper');
+  const carousel = sec.querySelector('.feat-swiper');
   const slides = sec.querySelectorAll('.swiper-slide');
   const arrows = Array.from(sec.querySelectorAll('button[aria-label]')).map((b) =>
     b.getAttribute('aria-label'),
@@ -33,22 +33,22 @@ const feat = await p.evaluate(() => {
   const img = sec.querySelector('.swiper-slide img');
   const imgCls = img ? img.className : '';
   return {
-    hasSwiper: !!swiper,
+    hasCarousel: !!carousel,
+    mode: carousel ? carousel.getAttribute('data-carousel-mode') : null,
     slideCount: slides.length,
     arrows,
-    loop: !!swiper && swiper.classList.contains('swiper-initialized'),
     hoverRing: imgCls.includes('hover:ring-white/50'),
     hoverGlow: imgCls.includes('shadow-[0_0_25px_6px_rgba(255,255,255,0.25)]'),
   };
 });
 console.log('FEATURING:', JSON.stringify(feat));
 
-// test infinite loop: record realIndex before/after slideNext
+// test infinite loop: record active index before/after slideNext
 const loopInfo = await p.evaluate(() => {
   const sec = document.getElementById('featuring');
-  const swiperEl = sec.querySelector('.swiper');
-  const swiper = swiperEl.__swiper__ || Object.values(swiperEl).find((v) => v && v.slideNext);
-  return { hasApi: !!swiper };
+  const carouselEl = sec.querySelector('.feat-swiper');
+  const carousel = carouselEl.__carousel__;
+  return { hasApi: !!carousel && typeof carousel.slideNext === 'function' };
 });
 console.log('FEATURING API access:', JSON.stringify(loopInfo));
 
@@ -119,7 +119,8 @@ const reg = await p2.evaluate(() => {
 });
 console.log('EVENTS register buttons:', JSON.stringify(reg));
 
-// open modal, check loop + arrows
+// open modal, check it renders slides + counter (the lightbox is
+// yet-another-react-lightbox, not a swiper — just confirm it opens)
 await p2.evaluate(() => {
   const poster = document.querySelector(
     'div[class*="relative"][class*="rounded-2xl"][class*="cursor-pointer"]',
@@ -133,12 +134,12 @@ await new Promise((r) => setTimeout(r, 1000));
 const modal = await p2.evaluate(() => {
   const d = document.querySelector('[role="dialog"]');
   if (!d) return null;
-  const nav = d.querySelectorAll('.swiper-button-prev, .swiper-button-next');
-  const swiperEl = d.querySelector('.swiper');
+  const imgs = d.querySelectorAll('img').length;
+  const counter = d.querySelector('.yarl\\.\\.counter, [class*="counter"]');
   return {
-    loop: swiperEl ? swiperEl.classList.contains('swiper-initialized') : false,
-    arrows: nav.length,
-    arrowVisible: nav.length ? getComputedStyle(nav[1]).display !== 'none' : false,
+    open: true,
+    imgs,
+    hasCounter: !!counter,
   };
 });
 console.log('MODAL:', JSON.stringify(modal));

--- a/scripts/probes/carousel-probe.mjs
+++ b/scripts/probes/carousel-probe.mjs
@@ -47,7 +47,9 @@ console.log('FEATURING:', JSON.stringify(feat));
 const loopInfo = await p.evaluate(() => {
   const sec = document.getElementById('featuring');
   const carouselEl = sec.querySelector('.feat-swiper');
-  const carousel = carouselEl.__carousel__;
+  // The carousel root may not have mounted yet (lazy chunk) — keep the
+  // diagnostic result instead of dereferencing null and aborting the probe.
+  const carousel = carouselEl?.__carousel__;
   return { hasApi: !!carousel && typeof carousel.slideNext === 'function' };
 });
 console.log('FEATURING API access:', JSON.stringify(loopInfo));

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,17 +11,17 @@ import { lazyWithRetry } from './utils/lazyWithRetry.js';
 import useDeviceProfile from './hooks/useLowPower.js';
 import { scrollToSectionWhenReady, targetIdFromLocation } from './utils/navigationCoordinator.js';
 
-// Below-the-fold sections are code-split: the heavy Swiper chunk (used by
-// Featuring + Execom) and the cube logic only download once the user scrolls
-// to them, shrinking the first-load bundle. AOS picks up the newly-mounted
-// [data-aos] elements via its built-in MutationObserver.
+// Below-the-fold sections are code-split: the carousel sections (Featuring +
+// Execom) and the cube logic only download once the user scrolls to them,
+// shrinking the first-load bundle. AOS picks up the newly-mounted [data-aos]
+// elements via its built-in MutationObserver.
 //
 // IMPORTANT: lazy sections must NOT all share one <Suspense> boundary — React
 // resolves every child of a suspended boundary in parallel, so a single
-// boundary would fire ALL the dynamic imports (including swiper-vendor) at
-// boot. Each section gets its own boundary; the two Swiper sections are
-// additionally wrapped in <ScrollGate>, which keeps them unmounted (and their
-// chunks undownloaded) until the user scrolls near them.
+// boundary would fire ALL the dynamic imports at boot. Each section gets its
+// own boundary; the two carousel sections are additionally wrapped in
+// <ScrollGate>, which keeps them unmounted (and their chunks undownloaded)
+// until the user scrolls near them.
 // Below-the-fold sections load through lazyWithRetry (same as the routes): a
 // chunk that fails to load — stale deployment hash, a network blip, or a
 // backgrounded tab that iOS evicted from memory — is retried once and then
@@ -70,7 +70,7 @@ function App() {
         <Suspense fallback={<SectionSkeleton height="100vh" label="Loading about" />}>
           <AboutUs />
         </Suspense>
-        {/* Swiper sections are scroll-gated: the chunk (swiper-vendor, ~300KB)
+        {/* Carousel sections are scroll-gated: the hand-rolled carousel chunk
             only downloads when the section approaches the viewport. The wrapper
             owns the section id, so anchors/scrollspy/tests still find it. */}
         <ScrollGate id="featuring" placeholderHeight="95vh" label="Loading featuring">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import { useLocation } from 'react-router';
 import { initAOS } from './utils/aosGating.js';
 import { lazyWithRetry } from './utils/lazyWithRetry.js';
 import useDeviceProfile from './hooks/useLowPower.js';
+import useAosFailsafe from './hooks/useAosFailsafe.js';
 import { scrollToSectionWhenReady, targetIdFromLocation } from './utils/navigationCoordinator.js';
 
 // Below-the-fold sections are code-split: the carousel sections (Featuring +
@@ -39,6 +40,8 @@ const Footer = lazyWithRetry(() => import('./Pages/LandingPage/Footer/Footer'));
 // unhide and never registers its observer — leaving every [data-aos] element
 // stuck invisible. So when gated, initAOS tags <body> and CSS force-shows all
 // [data-aos] content (including anything mounted later, e.g. lazy routes).
+// Capable devices get the viewport failsafe via useAosFailsafe (below) so a
+// broken AOS can never leave in-view content hidden.
 initAOS();
 
 function App() {
@@ -46,6 +49,12 @@ function App() {
   // reducedMotion comes from the device-profile seam (detectProfile), not a
   // raw matchMedia re-implementation — the same query, one owner.
   const { reducedMotion } = useDeviceProfile();
+  // The AOS viewport failsafe: force-show any in-view [data-aos] element AOS
+  // left hidden (its JS can break or miss an element — content must never
+  // stay hidden). Gated devices are already covered by the body.aos-disabled
+  // CSS net, so the hook is a no-op there. Lives in App: AOS only runs on the
+  // landing page (initAOS is module-scoped here).
+  useAosFailsafe();
 
   const pageH1 = <h1 className="sr-only">FOCES - Forum of Computer Engineering Students</h1>;
 

--- a/src/Components/Execom/TeamCarousel.jsx
+++ b/src/Components/Execom/TeamCarousel.jsx
@@ -1,10 +1,8 @@
 import { useRef, useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Swiper, SwiperSlide } from 'swiper/react';
-import { Autoplay, Navigation, EffectCube, Keyboard } from 'swiper/modules';
-import 'swiper/css';
-import 'swiper/css/effect-cube';
-import 'swiper/css/navigation';
+import { FaChevronLeft, FaChevronRight } from 'react-icons/fa6';
+import useCarousel from '../../hooks/useCarousel.js';
+import { useViewportWidth } from '../../hooks/useViewportWidth.js';
 import BlurImage from '../BlurImage/BlurImage';
 import {
   syncCarouselKeyboard,
@@ -12,24 +10,24 @@ import {
   registerWidget,
   rectIsOnScreen,
 } from '../../utils/keyboardLock.js';
-import { normalizeIndex, wrapTarget } from '../../utils/carouselWrap.js';
+import { copyFor } from '../../utils/carouselWrap.js';
 import { useAutoplayOnScreen } from '../../hooks/useAutoplayOnScreen.js';
 import '../Execom/custom.css';
 
 /**
- * TeamCarousel — one swiper for both Execom variants.
+ * TeamCarousel — one hand-rolled carousel for both Execom variants.
  *
- * Previously Execom carried two near-duplicate swiper blocks (desktop
- * cube/slider + mobile cube) differing only in a handful of props, plus two
- * identical 11-dot indicators and two identical slide renderers. This
- * component owns all of that: the swiper, the slide cards, the dots, the
- * seamless-wrap handler, the arrow-key arbitration registration, and the
- * on-screen autoplay gate. Execom just renders two instances with the
- * variant-specific props.
+ * Previously this was two near-duplicate Swiper blocks (desktop cube/slider +
+ * mobile cube) — now both render through the shared useCarousel seam, which
+ * owns the 3D cube (rotateY 90° per face, no shadows — they smear on the dark
+ * bg), the flat fallback (low-power/reduced-motion), swipe/touch drag with
+ * gesture ownership (touch-action: none + preventDefault), the arrow-key
+ * arbitration registration, and the on-screen autoplay gate.
  *
- * Both instances stay in the DOM (the other is hidden via CSS), so the E2E
- * selectors — .execom-swiper, .execom-cube-swiper, .container-execom and the
- * dots div as the swiper's direct sibling — are unchanged.
+ * The DOM contract the E2E suite and CSS rely on is unchanged: the root keeps
+ * .execom-swiper / .execom-cube-swiper, slides keep .swiper-slide (with
+ * .swiper-slide-active toggled), cards keep .container-execom, and the dots
+ * div stays the root's direct sibling.
  */
 function TeamCarousel({
   widgetId,
@@ -41,150 +39,149 @@ function TeamCarousel({
   activeIndex,
   onActiveChange,
 }) {
-  const swiperRef = useRef(null);
+  const elRef = useRef(null);
   const wrapRef = useRef(null);
+  const width = useViewportWidth();
 
   const total = slidesData.length;
   const isDesktop = variant === 'desktop';
 
-  // No swipe-shadows: they are the cube's #1 GPU cost and read as a black
-  // smear on the near-black site background.
-  const cubeEffectConfig = { shadow: false, slideShadows: false };
+  // Desktop flat mode is responsive (2/3/4 per view, like Swiper's
+  // breakpoints); everything else is 1 per view. Re-computed reactively via
+  // useViewportWidth, then fed to the hook (its re-style effect re-applies).
+  const perView =
+    flatCube && isDesktop ? (width >= 1280 ? 4 : width >= 1024 ? 3 : width >= 640 ? 2 : 1) : 1;
+  const gap = flatCube ? (isDesktop ? (width >= 1024 ? 24 : 20) : 20) : 0;
 
-  // Seamless infinite wrap (math in carouselWrap.js): the cube rotates 90°
-  // per face, so Swiper's loop mode can't be used — 3 copies of the cards are
-  // rendered and a 0ms jump between copies makes the wrap invisible (index 0
-  // and 32 share the same cube orientation). The flat slider uses the same
-  // copies instead of loop mode: Swiper's loop with only ~3× slidesPerView
-  // jams at its append boundary (autoplay/keyboard advance a few times, then
-  // freeze).
-  const handleWrap = useCallback(
-    (swiper) => {
-      if (!swiper) return;
-      const idx = swiper.activeIndex;
-      onActiveChange(normalizeIndex(idx, total));
-
-      const target = wrapTarget(idx, total);
-      if (target !== null) {
-        swiper.slideTo(target, 0);
-        // The 0ms jump fires no DOM transitionend, so Swiper autoplay's
-        // transition-wait would stay paused forever — nudge it back on.
-        swiper.autoplay?.resume();
-      }
-    },
-    [onActiveChange, total],
-  );
+  const { instanceRef, trackRef } = useCarousel({
+    elRef,
+    total,
+    mode: flatCube ? 'flat' : 'cube',
+    slidesPerView: perView,
+    spaceBetween: gap,
+    autoplayDelay: disableAutoplay ? 0 : isDesktop ? 3500 : 2500,
+    initialIndex: total,
+    speed: flatCube ? 250 : 400,
+    onActiveChange,
+  });
 
   // Arrow-key arbitration (see utils/keyboardLock.js): this carousel counts
-  // as "on screen" only while its swiper is actually rendered/visible (the
+  // as "on screen" only while its root is actually rendered/visible (the
   // other variant is hidden via CSS, which rectIsOnScreen detects), and it
   // enables its keyboard only while it owns the arrows. The widget's `el` is
-  // the WRAPPER div (parent of both the swiper AND the dots) — that way the
+  // the WRAPPER div (parent of both the root AND the dots) — that way the
   // dots are "inside" the widget, so clicking one keeps the arrow keys
   // driving the carousel (same containment the original Execom had).
   useEffect(() => {
     const unregister = registerWidget(
       widgetId,
-      () => rectIsOnScreen(swiperRef.current?.el, 60),
+      () => rectIsOnScreen(instanceRef.current?.el, 60),
       wrapRef.current,
     );
-    const sync = () => syncCarouselKeyboard(swiperRef.current, widgetId);
+    const sync = () => syncCarouselKeyboard(instanceRef.current, widgetId);
     sync(); // ownership may already be decided before this runs
     const unsub = subscribeKeyboardArbitration(sync);
     return () => {
       unregister();
       unsub();
     };
-  }, [widgetId]);
+  }, [widgetId, instanceRef]);
 
   // Only run autoplay while the carousel is actually on screen — at high CPU
   // throttle (or on low-end phones), a slider spinning off-screen is pure
   // wasted frames. Shared seam (useAutoplayOnScreen) — same hook Featuring
   // uses.
-  useAutoplayOnScreen({ elementRef: wrapRef, swiperRef, disable: disableAutoplay });
+  useAutoplayOnScreen({
+    elementRef: wrapRef,
+    swiperRef: instanceRef,
+    disable: disableAutoplay,
+  });
 
   const containerClass = isDesktop
     ? `hidden sm:block ${flatCube ? '' : 'max-w-[360px] mx-auto py-4'}`
     : 'block sm:hidden max-w-[320px] mx-auto py-4';
 
-  const autoplay = disableAutoplay
-    ? false
-    : { delay: isDesktop ? 3500 : 2500, disableOnInteraction: false };
+  const showNavArrows = isDesktop && flatCube;
+
+  const goToSlide = useCallback(
+    (i) => {
+      const sw = instanceRef.current;
+      if (!sw) return;
+      const copy = copyFor(sw.activeIndex, total);
+      sw.slideTo(copy * total + i, 350);
+    },
+    [instanceRef, total],
+  );
 
   return (
     <div ref={wrapRef} className={containerClass}>
-      <Swiper
-        onSwiper={(swiper) => {
-          swiperRef.current = swiper;
-          syncCarouselKeyboard(swiper, widgetId);
-        }}
-        modules={[Autoplay, Navigation, EffectCube, Keyboard]}
-        effect={flatCube ? 'slide' : 'cube'}
-        speed={flatCube ? 250 : 400}
-        cubeEffect={cubeEffectConfig}
-        grabCursor={isDesktop ? !flatCube : true}
-        spaceBetween={flatCube ? 20 : 0}
-        slidesPerView={1}
-        initialSlide={total}
-        autoplay={autoplay}
-        navigation={isDesktop && flatCube}
-        keyboard={{ enabled: true, onlyInViewport: false }}
-        // Wrap on transition END (not slideChange): the 0ms wrap jump emits
-        // no transitionend, which would leave Swiper autoplay paused forever.
-        onTouchEnd={handleWrap}
-        onTransitionEnd={handleWrap}
-        breakpoints={
-          flatCube && isDesktop
-            ? {
-                640: { slidesPerView: 2, spaceBetween: 20 },
-                1024: { slidesPerView: 3, spaceBetween: 24 },
-                1280: { slidesPerView: 4, spaceBetween: 24 },
-              }
-            : undefined
-        }
-        className={isDesktop ? 'execom-swiper pb-12' : 'execom-cube-swiper'}
+      <div
+        ref={elRef}
+        className={`${isDesktop ? 'execom-swiper pb-12' : 'execom-cube-swiper'} relative ${
+          flatCube ? '' : 'cursor-grab active:cursor-grabbing'
+        }`}
       >
-        {slides.map((d, index) => (
-          <SwiperSlide key={index}>
-            <div
-              className={`container-execom bg-[#161618] border-box relative rounded-3xl overflow-hidden ${
-                isDesktop ? 'group' : ''
-              }`}
-            >
-              <BlurImage
-                className={`object-cover ${
-                  d.name === 'Sebin Mathew' ? 'object-center' : 'object-top'
-                } w-full h-full ${isDesktop ? 'card-hover' : ''} grayscale group-hover:filter-none transition-all duration-300`}
-                src={d.img}
-                alt={d.name}
-                loading="lazy"
-                decoding="async"
-              />
-              <div className="absolute rounded-b-3xl bottom-0 w-full bg-gradient-to-t from-black via-black/85 to-transparent p-4 text-left">
-                <div className="text-white text-base font-semibold italic">{d.name}</div>
-                <div className="text-gray-300 text-xs font-light">{d.role}</div>
+        <div ref={trackRef} className="swiper-wrapper">
+          {slides.map((d, index) => (
+            <div key={index} className="swiper-slide">
+              <div
+                className={`container-execom bg-[#161618] border-box relative rounded-3xl overflow-hidden ${
+                  isDesktop ? 'group' : ''
+                }`}
+              >
+                <BlurImage
+                  className={`object-cover ${
+                    d.name === 'Sebin Mathew' ? 'object-center' : 'object-top'
+                  } w-full h-full ${isDesktop ? 'card-hover' : ''} grayscale group-hover:filter-none transition-all duration-300`}
+                  src={d.img}
+                  alt={d.name}
+                  loading="lazy"
+                  decoding="async"
+                />
+                <div className="absolute rounded-b-3xl bottom-0 w-full bg-gradient-to-t from-black via-black/85 to-transparent p-4 text-left">
+                  <div className="text-white text-base font-semibold italic">{d.name}</div>
+                  <div className="text-gray-300 text-xs font-light">{d.role}</div>
+                </div>
               </div>
             </div>
-          </SwiperSlide>
-        ))}
-      </Swiper>
+          ))}
+        </div>
+        {/* Flat desktop mode keeps prev/next arrows (Swiper's navigation was
+            rendered by the library; here they're plain buttons). */}
+        {showNavArrows && (
+          <>
+            <button
+              type="button"
+              aria-label="Previous team member"
+              onClick={() => instanceRef.current?.slidePrev()}
+              className="absolute left-0 top-1/2 -translate-y-1/2 z-20 w-10 h-10 flex items-center justify-center rounded-full bg-black/40 hover:bg-black/70 text-white text-lg transition-colors duration-200 backdrop-blur-sm"
+            >
+              <FaChevronLeft />
+            </button>
+            <button
+              type="button"
+              aria-label="Next team member"
+              onClick={() => instanceRef.current?.slideNext()}
+              className="absolute right-0 top-1/2 -translate-y-1/2 z-20 w-10 h-10 flex items-center justify-center rounded-full bg-black/40 hover:bg-black/70 text-white text-lg transition-colors duration-200 backdrop-blur-sm"
+            >
+              <FaChevronRight />
+            </button>
+          </>
+        )}
+      </div>
 
-      {/* Custom 11-dot indicator — Swiper's loop was replaced with duplicated
-          slides, so its pagination (which would render 3× bullets) can't be
-          used. Sits as the swiper's direct sibling (selectors in the E2E
-          suite depend on .execom-swiper + div / .execom-cube-swiper + div). */}
+      {/* Custom 11-dot indicator — the 3-copy wrap means the dots can't be
+          generated from the raw index; they map to the logical slides and
+          jump within the current copy. Sits as the root's direct sibling
+          (selectors in the E2E suite depend on .execom-swiper + div /
+          .execom-cube-swiper + div). */}
       <div className="flex justify-center gap-2 mt-2 pb-1">
         {slidesData.map((d, i) => (
           <button
             key={i}
             type="button"
             aria-label={`Go to ${d.name}`}
-            onClick={() => {
-              const sw = swiperRef.current;
-              if (!sw) return;
-              const copy = Math.floor(sw.activeIndex / total);
-              sw.slideTo(copy * total + i, 350);
-            }}
+            onClick={() => goToSlide(i)}
             // 8px dot on a 24px hit area (WCAG 2.2.8 target size): the button
             // is a genuine 24×24 box (min-w-6/min-h-6) with the visible dot
             // centered inside — no padding/margin tricks, which axe reads as

--- a/src/Components/Execom/custom.css
+++ b/src/Components/Execom/custom.css
@@ -6,21 +6,34 @@
     width: 250px;
 }
 
-/* Desktop/tablet carousel pagination sits in the swiper's bottom padding,
-   below the member cards — never over the photo/gradient overlay. The
-   padding lives here (not Tailwind utilities) because Swiper's own
-   `.swiper { padding: 0 }` overrides utilities due to stylesheet order. */
+/* The hand-rolled carousel owns its touch gesture (same rule as the About
+   cube): rotating the cube / dragging the flat slider must never scroll the
+   page, and a pan-y allowance would let diagonal drags jump the viewport.
+   The hook's pointer handlers preventDefault non-passive pointermoves to
+   cover the gesture in JS (ADR-0007). */
 .execom-swiper {
-    /* The carousel owns its touch gesture (same rule as the About cube):
-       rotating the cube must never scroll the page, and a pan-y allowance
-       would let diagonal drags jump the viewport. Swiper's own non-passive
-       touchmove preventDefault then covers the gesture in JS. */
     touch-action: none;
-    padding-bottom: 52px;
-    --swiper-pagination-bottom: 4px;
-    --swiper-pagination-color: white;
-    --swiper-pagination-bullet-inactive-opacity: 0.5;
-    --swiper-pagination-bullet-inactive-color: white;
+}
+
+/* Cube visibility: every face is absolutely positioned by the hook; only the
+   active/next/prev faces are interactive and painted (the rest are rotated
+   away — same policy Swiper's cube CSS had).
+
+   Failsafe: the hiding is gated on data-carousel-ready, which the hook sets
+   ONLY after it has applied the first transforms + active classes. If the
+   carousel chunk fails or the hook errors before that point, the faces stay
+   visible (stacked, unrotated) instead of the whole section going blank —
+   content must never be hidden by a JS failure. */
+[data-carousel-mode='cube'][data-carousel-ready] .swiper-slide {
+    visibility: hidden;
+    pointer-events: none;
+}
+
+[data-carousel-mode='cube'][data-carousel-ready] .swiper-slide-active,
+[data-carousel-mode='cube'][data-carousel-ready] .swiper-slide-next,
+[data-carousel-mode='cube'][data-carousel-ready] .swiper-slide-prev {
+    visibility: visible;
+    pointer-events: auto;
 }
 
 .container-execom {
@@ -66,11 +79,11 @@
 }
 
 /* GPU-friendly compositing for the 3D cube (smoother swipes on low-end devices) */
-.execom-cube-swiper .swiper-slide {
+[data-carousel-mode='cube'] .swiper-slide {
     -webkit-backface-visibility: hidden;
     backface-visibility: hidden;
 }
 
-.execom-cube-swiper .swiper-wrapper {
+[data-carousel-mode='cube'] .swiper-wrapper {
     will-change: transform;
 }

--- a/src/Pages/LandingPages/Featuring.css
+++ b/src/Pages/LandingPages/Featuring.css
@@ -1,21 +1,8 @@
-/* Featuring carousel — Swiper pagination theming and centering */
+/* Featuring carousel — the hand-rolled flat slider. The hook styles the
+   track (flex, gap) and slides (flex-basis) inline; this file only carries
+   the fixed paddings that frame the carousel inside the section. */
 .feat-swiper {
     padding-left: 3.5rem;
     padding-right: 3.5rem;
     padding-bottom: 2.5rem;
-    --swiper-pagination-color: white;
-    --swiper-pagination-bullet-inactive-opacity: 0.5;
-    --swiper-pagination-bullet-inactive-color: white;
-    --swiper-pagination-bottom: 0px;
-}
-
-.feat-swiper .swiper-wrapper {
-    display: flex !important;
-    align-items: center !important;
-}
-
-.feat-swiper .swiper-slide {
-    display: flex !important;
-    align-items: center !important;
-    justify-content: center !important;
 }

--- a/src/Pages/LandingPages/Featuring.jsx
+++ b/src/Pages/LandingPages/Featuring.jsx
@@ -1,8 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useViewportWidth } from '../../hooks/useViewportWidth.js';
-import { Swiper, SwiperSlide } from 'swiper/react';
-import { Autoplay, Scrollbar, A11y, Keyboard } from 'swiper/modules';
-import 'swiper/css';
+import useCarousel from '../../hooks/useCarousel.js';
 import { FaChevronLeft, FaChevronRight } from 'react-icons/fa6';
 import useDeviceProfile from '../../hooks/useLowPower.js';
 import { useAutoplayOnScreen } from '../../hooks/useAutoplayOnScreen.js';
@@ -10,7 +8,7 @@ import BlurImage from '../../Components/BlurImage/BlurImage';
 import featuring from '../../assets/featuring.svg';
 import { echoSlides, carouselSlides } from '../../data/echoSlides.js';
 import { featuringSlidesPerView, DESKTOP_MIN, SMALL_SCREEN_MAX } from '../../utils/breakpoints.js';
-import { normalizeIndex, wrapTarget, copyFor } from '../../utils/carouselWrap.js';
+import { copyFor } from '../../utils/carouselWrap.js';
 import {
   syncCarouselKeyboard,
   subscribeKeyboardArbitration,
@@ -25,28 +23,20 @@ function Featuring() {
   const disableAutoplay = reducedMotion;
   const noSlides = featuringSlidesPerView(useViewportWidth());
   const [activeSlide, setActiveSlide] = useState(0);
-  const swiperRef = useRef(null);
+  const elRef = useRef(null);
   const carouselRef = useRef(null);
   const sectionRef = useRef(null);
 
-  // Seamless infinite wrap: as soon as a copy boundary is crossed, jump 0ms
-  // to the equivalent slide in the adjacent copy (same content → invisible).
-  // The copy math lives in the shared, tested carouselWrap seam (same module
-  // TeamCarousel uses); this handler only performs the swiper side effects.
-  const handleWrap = useCallback((swiper) => {
-    if (!swiper) return;
-    const total = echoSlides.length;
-    const idx = swiper.activeIndex;
-    setActiveSlide(normalizeIndex(idx, total));
-
-    const target = wrapTarget(idx, total);
-    if (target != null) {
-      swiper.slideTo(target, 0);
-      // The 0ms jump fires no DOM transitionend, so Swiper autoplay's
-      // transition-wait would stay paused forever — nudge it back on.
-      swiper.autoplay?.resume();
-    }
-  }, []);
+  const { instanceRef, trackRef } = useCarousel({
+    elRef,
+    total: echoSlides.length,
+    mode: 'flat',
+    slidesPerView: noSlides,
+    spaceBetween: 50,
+    autoplayDelay: disableAutoplay ? 0 : 3500,
+    initialIndex: echoSlides.length,
+    onActiveChange: setActiveSlide,
+  });
 
   // Arrow-key arbitration (see utils/keyboardLock.js): register the carousel
   // as a widget and enable its keyboard only while it owns the arrows (on
@@ -56,10 +46,10 @@ function Featuring() {
     const id = 'featuring';
     const unregister = registerWidget(
       id,
-      () => rectIsOnScreen(swiperRef.current?.el, 60),
+      () => rectIsOnScreen(instanceRef.current?.el, 60),
       sectionRef.current, // section wrapper includes the arrows AND the dot indicator
     );
-    const sync = () => syncCarouselKeyboard(swiperRef.current, id);
+    const sync = () => syncCarouselKeyboard(instanceRef.current, id);
     const mark = () => markInteracted(id);
     sync(); // ownership may already be decided before this runs
     const carouselEl = carouselRef.current;
@@ -70,11 +60,36 @@ function Featuring() {
       unsub();
       carouselEl?.removeEventListener('pointerdown', mark, true);
     };
-  }, []);
+  }, [instanceRef]);
 
   // Only run autoplay while the carousel is on screen (shared seam —
   // useAutoplayOnScreen, same hook TeamCarousel uses).
-  useAutoplayOnScreen({ elementRef: carouselRef, swiperRef, disable: disableAutoplay });
+  useAutoplayOnScreen({
+    elementRef: carouselRef,
+    swiperRef: instanceRef,
+    disable: disableAutoplay,
+  });
+
+  // The seamless loop renders 3 copies of the slides; label each copy with
+  // the real position so screen readers announce "1 / 4" instead of "N / 12".
+  // (The old Swiper set these on the slides in its onSwiper hook.)
+  useEffect(() => {
+    const slides = instanceRef.current?.slides;
+    if (!slides) return;
+    slides.forEach((el, i) =>
+      el.setAttribute('aria-label', `${(i % echoSlides.length) + 1} / ${echoSlides.length}`),
+    );
+  }, [instanceRef]);
+
+  const goToSlide = useCallback(
+    (i) => {
+      const sw = instanceRef.current;
+      if (!sw) return;
+      const copy = copyFor(sw.activeIndex, echoSlides.length);
+      sw.slideTo(copy * echoSlides.length + i, 350);
+    },
+    [instanceRef],
+  );
 
   // The section id lives on the ScrollGate wrapper in App.jsx, not here —
   // the wrapper is always present, so anchors/scrollspy always find it.
@@ -104,81 +119,54 @@ function Featuring() {
         <button
           type="button"
           aria-label="Previous ECHO photos"
-          onClick={() => swiperRef.current?.slidePrev()}
+          onClick={() => instanceRef.current?.slidePrev()}
           className="absolute left-2 top-1/2 -translate-y-1/2 z-20 w-10 h-10 flex items-center justify-center rounded-full bg-black/40 hover:bg-black/70 text-white text-lg transition-colors duration-200 backdrop-blur-sm"
         >
           <FaChevronLeft />
         </button>
-        <Swiper
-          modules={[Autoplay, Scrollbar, A11y, Keyboard]}
-          slidesPerView={noSlides}
-          spaceBetween={50}
-          initialSlide={echoSlides.length}
-          autoplay={disableAutoplay ? false : { delay: 3500, disableOnInteraction: false }}
-          scrollbar={{ draggable: true }}
-          keyboard={{ enabled: true, onlyInViewport: false }}
-          onSwiper={(swiper) => {
-            swiperRef.current = swiper;
-            syncCarouselKeyboard(swiper, 'featuring');
-            // The seamless loop renders 3 copies of 4 slides; tell screen
-            // readers the real count instead of "N / 12".
-            swiper.slides.forEach((el, i) =>
-              el.setAttribute(
-                'aria-label',
-                `${(i % echoSlides.length) + 1} / ${echoSlides.length}`,
-              ),
-            );
-          }}
-          // Wrap on transition END (not slideChange): the 0ms wrap jump emits
-          // no transitionend, which would leave Swiper autoplay paused forever.
-          onTouchEnd={handleWrap}
-          onTransitionEnd={handleWrap}
-          className="feat-swiper bg-transparent h-fit"
-        >
-          {carouselSlides.map(({ image, imageSet, blur, alt }, index) => (
-            <SwiperSlide key={index} className="px-3 pt-9 pb-8 bg-transparent">
-              {/* data-aos lives on the wrapper, not the img: AOS's [data-aos]
-                  opacity rules would override the blur-up fade (higher CSS
-                  specificity than Tailwind's opacity-0/100), so the reveal
-                  animates the whole card while BlurImage fades independently. */}
-              <div data-aos="flip-right" data-aos-duration="1000">
-                <BlurImage
-                  className="h-full w-full rounded-2xl object-cover transition-all duration-300 shadow-xl hover:scale-105 hover:ring-2 hover:ring-white/50 hover:shadow-[0_0_25px_6px_rgba(255,255,255,0.25)]"
-                  src={image}
-                  srcSet={imageSet}
-                  sizes={`(min-width: ${DESKTOP_MIN}px) 33vw, (min-width: ${SMALL_SCREEN_MAX}px) 50vw, 90vw`}
-                  blurSrc={blur}
-                  alt={alt}
-                  loading="lazy"
-                  decoding="async"
-                />
+        <div ref={elRef} className="feat-swiper bg-transparent h-fit">
+          <div ref={trackRef} className="swiper-wrapper">
+            {carouselSlides.map(({ image, imageSet, blur, alt }, index) => (
+              <div key={index} className="swiper-slide px-3 pt-9 pb-8 bg-transparent">
+                {/* data-aos lives on the wrapper, not the img: AOS's [data-aos]
+                    opacity rules would override the blur-up fade (higher CSS
+                    specificity than Tailwind's opacity-0/100), so the reveal
+                    animates the whole card while BlurImage fades independently. */}
+                <div data-aos="flip-right" data-aos-duration="1000">
+                  <BlurImage
+                    className="h-full w-full rounded-2xl object-cover transition-all duration-300 shadow-xl hover:scale-105 hover:ring-2 hover:ring-white/50 hover:shadow-[0_0_25px_6px_rgba(255,255,255,0.25)]"
+                    src={image}
+                    srcSet={imageSet}
+                    sizes={`(min-width: ${DESKTOP_MIN}px) 33vw, (min-width: ${SMALL_SCREEN_MAX}px) 50vw, 90vw`}
+                    blurSrc={blur}
+                    alt={alt}
+                    loading="lazy"
+                    decoding="async"
+                  />
+                </div>
               </div>
-            </SwiperSlide>
-          ))}
-        </Swiper>
+            ))}
+          </div>
+        </div>
         <button
           type="button"
           aria-label="Next ECHO photos"
-          onClick={() => swiperRef.current?.slideNext()}
+          onClick={() => instanceRef.current?.slideNext()}
           className="absolute right-2 top-1/2 -translate-y-1/2 z-20 w-10 h-10 flex items-center justify-center rounded-full bg-black/40 hover:bg-black/70 text-white text-lg transition-colors duration-200 backdrop-blur-sm"
         >
           <FaChevronRight />
         </button>
       </div>
-      {/* Custom 4-dot indicator — Swiper's loop mode was replaced with duplicated
-          slides, so its pagination (which would render 12 bullets) can't be used. */}
+      {/* Custom 4-dot indicator — the 3-copy wrap means the dots can't be
+          generated from the raw index; they map to the logical slides and
+          jump within the current copy. */}
       <div className="flex justify-center gap-2 mt-2 feat-dots">
         {echoSlides.map((slide, i) => (
           <button
             key={i}
             type="button"
             aria-label={`Go to ${slide.alt}`}
-            onClick={() => {
-              const sw = swiperRef.current;
-              if (!sw) return;
-              const copy = copyFor(sw.activeIndex, echoSlides.length);
-              sw.slideTo(copy * echoSlides.length + i, 350);
-            }}
+            onClick={() => goToSlide(i)}
             // 8px dot on a 24px hit area (WCAG 2.2.8 target size): the button
             // is a genuine 24×24 box (min-w-6/min-h-6) with the visible dot
             // centered inside — no padding/margin tricks, which axe reads as

--- a/src/Pages/LandingPages/Featuring.jsx
+++ b/src/Pages/LandingPages/Featuring.jsx
@@ -19,8 +19,8 @@ import {
 import './Featuring.css';
 
 function Featuring() {
-  const { reducedMotion } = useDeviceProfile();
-  const disableAutoplay = reducedMotion;
+  const { reducedMotion, lowPower } = useDeviceProfile();
+  const disableAutoplay = reducedMotion || lowPower;
   const noSlides = featuringSlidesPerView(useViewportWidth());
   const [activeSlide, setActiveSlide] = useState(0);
   const elRef = useRef(null);
@@ -127,7 +127,12 @@ function Featuring() {
         <div ref={elRef} className="feat-swiper bg-transparent h-fit">
           <div ref={trackRef} className="swiper-wrapper">
             {carouselSlides.map(({ image, imageSet, blur, alt }, index) => (
-              <div key={index} className="swiper-slide px-3 pt-9 pb-8 bg-transparent">
+              <div
+                key={index}
+                role="group"
+                aria-roledescription="slide"
+                className="swiper-slide px-3 pt-9 pb-8 bg-transparent"
+              >
                 {/* data-aos lives on the wrapper, not the img: AOS's [data-aos]
                     opacity rules would override the blur-up fade (higher CSS
                     specificity than Tailwind's opacity-0/100), so the reveal

--- a/src/hooks/useAosFailsafe.js
+++ b/src/hooks/useAosFailsafe.js
@@ -12,7 +12,8 @@
 // Gated devices are skipped — they already get the CSS net, so the JS watch
 // would be redundant there. The decision functions (shouldForceShowAos /
 // stuckAosInView / aosDisabled) live in utils/aosGating.js; this hook owns
-// only the browser lifecycle (listeners, rAF, cleanup) per ADR-0009.
+// only the browser lifecycle (listeners, rAF, MutationObserver, cleanup) per
+// ADR-0009.
 import { useEffect } from 'react';
 import { aosDisabled, stuckAosInView } from '../utils/aosGating.js';
 
@@ -33,10 +34,18 @@ export default function useAosFailsafe() {
     };
     window.addEventListener('scroll', schedule, { passive: true });
     window.addEventListener('resize', schedule);
+    // Scroll-gated lazy sections mount their [data-aos] elements AFTER boot.
+    // AOS's own MutationObserver would catch them, but if AOS is broken a
+    // mounted in-view element could stay hidden with no scroll/resize ever
+    // firing — so observe child-list mutations and re-scan. rAF coalescing
+    // keeps this at most one scan per frame.
+    const observer = new MutationObserver(schedule);
+    observer.observe(document.body, { childList: true, subtree: true });
     forceShow(); // elements already in the viewport at boot
 
     return () => {
       if (rafId) cancelAnimationFrame(rafId);
+      observer.disconnect();
       window.removeEventListener('scroll', schedule);
       window.removeEventListener('resize', schedule);
     };

--- a/src/hooks/useAosFailsafe.js
+++ b/src/hooks/useAosFailsafe.js
@@ -1,0 +1,44 @@
+// The app-lifetime AOS viewport failsafe, mounted once in App.
+//
+// On capable devices, the only thing that ever reveals [data-aos] content is
+// AOS's own scroll observer — if its JS breaks, throws, or misses an element
+// (a race with a lazy chunk's MutationObserver), visible content can stay
+// opacity:0 forever. This backstop force-shows any in-view [data-aos] element
+// AOS left hidden, giving capable devices the same guarantee the
+// body.aos-disabled CSS net gives gated ones. It only touches what is
+// actually on screen, so below-the-fold scroll reveals are untouched when AOS
+// works.
+//
+// Gated devices are skipped — they already get the CSS net, so the JS watch
+// would be redundant there. The decision functions (shouldForceShowAos /
+// stuckAosInView / aosDisabled) live in utils/aosGating.js; this hook owns
+// only the browser lifecycle (listeners, rAF, cleanup) per ADR-0009.
+import { useEffect } from 'react';
+import { aosDisabled, stuckAosInView } from '../utils/aosGating.js';
+
+export default function useAosFailsafe() {
+  useEffect(() => {
+    if (aosDisabled()) return undefined;
+
+    let rafId = 0;
+    const forceShow = () => {
+      stuckAosInView().forEach((el) => el.classList.add('aos-animate'));
+    };
+    const schedule = () => {
+      if (rafId) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = 0;
+        forceShow();
+      });
+    };
+    window.addEventListener('scroll', schedule, { passive: true });
+    window.addEventListener('resize', schedule);
+    forceShow(); // elements already in the viewport at boot
+
+    return () => {
+      if (rafId) cancelAnimationFrame(rafId);
+      window.removeEventListener('scroll', schedule);
+      window.removeEventListener('resize', schedule);
+    };
+  }, []);
+}

--- a/src/hooks/useAutoplayOnScreen.js
+++ b/src/hooks/useAutoplayOnScreen.js
@@ -3,7 +3,9 @@ import { useEffect } from 'react';
 // Autoplay-on-screen gating — one seam for both carousels (Featuring and
 // Execom's TeamCarousel used to implement the identical IntersectionObserver
 // effect; the "two implementations of one behavior" signal). The decision is
-// pure; the hook wires it to the DOM.
+// pure; the hook wires it to the DOM. The `swiperRef` name is legacy — it now
+// holds the hand-rolled useCarousel instance, which keeps the same
+// autoplay.start/stop shape.
 //
 //   autoplayGate(visible, disable)  — 'start' | 'stop'
 //   useAutoplayOnScreen(...)        — observe the carousel wrapper; start

--- a/src/hooks/useCarousel.js
+++ b/src/hooks/useCarousel.js
@@ -76,6 +76,7 @@ export default function useCarousel({
     lastMoveT: 0,
     velocity: 0,
     autoplayTimer: null,
+    dragAutoplayWasOn: false,
     keyboardOn: false,
     faceWidth: 0,
     slideWidth: 0,
@@ -200,6 +201,13 @@ export default function useCarousel({
 
   // --- keyboard (arbitrated by keyboardLock.js via enable/disable) ---------
 
+  // onKeyDown is re-created every render, so the handler actually registered
+  // on window must be stored — removeEventListener must drop THAT exact
+  // function. Otherwise a re-render before disableKeyboard() would remove the
+  // new closure while the original stayed registered, and arrow keys would
+  // keep driving (and preventDefault-ing on) a stale/unmounted instance.
+  const keydownHandler = useRef(null);
+
   function onKeyDown(e) {
     if (e.key === 'ArrowLeft') {
       e.preventDefault();
@@ -213,13 +221,17 @@ export default function useCarousel({
   function enableKeyboard() {
     if (s.keyboardOn) return;
     s.keyboardOn = true;
-    window.addEventListener('keydown', onKeyDown);
+    keydownHandler.current = onKeyDown;
+    window.addEventListener('keydown', keydownHandler.current);
   }
 
   function disableKeyboard() {
     if (!s.keyboardOn) return;
     s.keyboardOn = false;
-    window.removeEventListener('keydown', onKeyDown);
+    if (keydownHandler.current) {
+      window.removeEventListener('keydown', keydownHandler.current);
+      keydownHandler.current = null;
+    }
   }
 
   // --- drag (pointer events; touch-action: none owns the gesture) ----------
@@ -230,6 +242,12 @@ export default function useCarousel({
     if (s.dragging) return;
     if (e.pointerType === 'mouse' && e.button !== 0) return;
     s.dragging = true;
+    // Pause autoplay for the duration of the drag: the interval must not fire
+    // a goTo() mid-gesture (it would move the track under the user's finger
+    // and corrupt the release snap). Remember it was running so onPointerUp
+    // can resume it.
+    s.dragAutoplayWasOn = !!s.autoplayTimer;
+    if (s.autoplayTimer) stopAutoplay();
     s.pointerId = e.pointerId;
     s.dragStartX = e.clientX;
     s.dragOffset = 0;
@@ -285,10 +303,10 @@ export default function useCarousel({
     s.dragOffset = 0;
     s.velocity = 0;
     goTo(s.raw + snap, true);
-    // Interaction resets the autoplay timer but doesn't stop it
-    // (disableOnInteraction: false — same policy Swiper had).
-    if (s.autoplayTimer) {
-      stopAutoplay();
+    // Resume autoplay if the drag paused it (disableOnInteraction: false —
+    // interaction resets the timer but doesn't stop autoplay permanently).
+    if (s.dragAutoplayWasOn) {
+      s.dragAutoplayWasOn = false;
       startAutoplay();
     }
   }

--- a/src/hooks/useCarousel.js
+++ b/src/hooks/useCarousel.js
@@ -1,0 +1,424 @@
+import { useRef, useLayoutEffect, useEffect } from 'react';
+import {
+  flatTrackTransform,
+  cubeTrackTransform,
+  cubeFaceTransform,
+  cubeDragAngle,
+  dragSnap,
+  slideStep,
+} from '../utils/carouselGeometry.js';
+import { normalizeIndex, wrapTarget } from '../utils/carouselWrap.js';
+
+/**
+ * Hand-rolled carousel — replaces Swiper (react) for the two carousels on the
+ * site (Featuring's flat slider and Execom's 3D cube), keeping the behaviors
+ * the site relied on: the cube rotates 90° per face (matching EffectCube with
+ * shadows off), swipe/touch drag with `touch-action: none` + preventDefault
+ * gesture ownership, arrow-key arbitration through keyboardLock.js, autoplay
+ * gated by useAutoplayOnScreen, and the seamless 3-copy wrap (carouselWrap).
+ *
+ * The instance is swiper-shaped on purpose — the seams that consumed Swiper
+ * (syncCarouselKeyboard, useAutoplayOnScreen, rectIsOnScreen, the E2E suite)
+ * keep working unchanged: it exposes `el`, `slides`, `activeIndex`,
+ * `slideTo/slidePrev/slideNext`, `keyboard.enable/disable` and
+ * `autoplay.start/stop/resume`. The DOM keeps the `.swiper-slide` /
+ * `.swiper-wrapper` class names (they are the stable hooks the E2E suite and
+ * CSS use) — only the engine is gone.
+ *
+ * Geometry (pure math in carouselGeometry.js):
+ *   flat — track translate3d(-activeIndex * step); slides flex-sized
+ *   cube — each face `rotateY(i * 90deg) translateZ(radius)`; track rotates
+ *          `-activeIndex * 90deg` around the face-center origin
+ *
+ * @param {object} opts
+ * @param {React.RefObject<HTMLElement>} opts.elRef — the carousel root (the
+ *   element carrying .feat-swiper / .execom-swiper / .execom-cube-swiper)
+ * @param {number} opts.total — logical slide count (before the 3-copy wrap)
+ * @param {'flat' | 'cube'} opts.mode
+ * @param {number} [opts.slidesPerView=1] — flat mode visible slides
+ * @param {number} [opts.spaceBetween=0] — flat mode gap between slides (px)
+ * @param {number} [opts.autoplayDelay=0] — ms between autoplay turns (0 = off)
+ * @param {number} [opts.initialIndex] — raw index to start at (default: the
+ *   middle copy, `total`, so the wrap never trips on mount)
+ * @param {number} [opts.speed=350] — transition ms for animated moves
+ * @param {(normalizedIndex: number) => void} [opts.onActiveChange] — fired
+ *   with the normalized (0..total-1) index on every settle
+ * @returns {{ instanceRef: React.RefObject<object>, trackRef: React.RefObject<HTMLElement> }}
+ */
+export default function useCarousel({
+  elRef,
+  total,
+  mode,
+  slidesPerView = 1,
+  spaceBetween = 0,
+  autoplayDelay = 0,
+  initialIndex,
+  speed = 350,
+  onActiveChange,
+}) {
+  const trackRef = useRef(null);
+  const instanceRef = useRef(null);
+
+  // The instance + handlers are created once and read the latest props/DOM
+  // through refs — no stale closures, no re-created listeners.
+  const propsRef = useRef({ total, mode, slidesPerView, spaceBetween, autoplayDelay, speed });
+  propsRef.current = { total, mode, slidesPerView, spaceBetween, autoplayDelay, speed };
+  const onActiveChangeRef = useRef(onActiveChange);
+  onActiveChangeRef.current = onActiveChange;
+
+  const s = useRef({
+    raw: initialIndex ?? total,
+    dragging: false,
+    pointerId: null,
+    dragStartX: 0,
+    dragOffset: 0,
+    lastMoveX: 0,
+    lastMoveT: 0,
+    velocity: 0,
+    autoplayTimer: null,
+    keyboardOn: false,
+    faceWidth: 0,
+    slideWidth: 0,
+    step: 0,
+  }).current;
+
+  const track = () => trackRef.current;
+  const root = () => elRef.current;
+  const p = () => propsRef.current;
+
+  // --- measurement ---------------------------------------------------------
+
+  function measure() {
+    const t = track();
+    if (!t) return;
+    const { mode: m, spaceBetween: gap } = p();
+    if (m === 'cube') {
+      s.faceWidth = t.clientWidth || root()?.clientWidth || 0;
+      // Slides are absolutely positioned (no in-flow height), so the track
+      // must be sized explicitly — the card inside has a fixed CSS height.
+      const firstCard = t.firstElementChild?.firstElementChild;
+      const h = firstCard ? firstCard.offsetHeight : 0;
+      if (h) t.style.height = `${h}px`;
+    } else {
+      const first = t.firstElementChild;
+      s.slideWidth = first ? first.getBoundingClientRect().width : 0;
+      s.step = slideStep(s.slideWidth, gap);
+    }
+  }
+
+  // --- transforms ----------------------------------------------------------
+
+  function syncActiveClasses() {
+    const t = track();
+    if (!t) return;
+    const children = Array.from(t.children);
+    const raw = s.raw;
+    children.forEach((slide, i) => {
+      slide.classList.toggle('swiper-slide-active', i === raw);
+      slide.classList.toggle('swiper-slide-next', i === raw + 1);
+      slide.classList.toggle('swiper-slide-prev', i === raw - 1);
+    });
+  }
+
+  function applyTransforms() {
+    const t = track();
+    if (!t) return;
+    const { mode: m } = p();
+    if (m === 'cube') {
+      Array.from(t.children).forEach((slide, i) => {
+        slide.style.transform = cubeFaceTransform(i, s.faceWidth / 2);
+      });
+      t.style.transform = cubeTrackTransform(
+        s.raw,
+        s.dragging ? cubeDragAngle(s.dragOffset, s.faceWidth) : 0,
+      );
+    } else {
+      t.style.transform = flatTrackTransform(s.raw, s.step, s.dragging ? s.dragOffset : 0);
+    }
+    syncActiveClasses();
+    // Failsafe gate (see Execom/custom.css): only once the first transforms
+    // and active classes are in place may the cube CSS hide the non-visible
+    // faces. Reaching here means the hook is alive — before this point the
+    // faces stay visible (stacked) rather than the section going blank on a
+    // chunk/JS failure.
+    root()?.setAttribute('data-carousel-ready', '');
+  }
+
+  // --- navigation ----------------------------------------------------------
+
+  function goTo(rawIndex, animate = true, msSpeed) {
+    const t = track();
+    if (!t) return;
+    const { total: n, speed: defaultSpeed } = p();
+    const clamped = Math.max(0, Math.min(rawIndex, n * 3 - 1));
+    s.raw = clamped;
+    t.style.transition = animate
+      ? `transform ${msSpeed ?? defaultSpeed}ms cubic-bezier(0.25, 1, 0.5, 1)`
+      : 'none';
+    applyTransforms();
+    onActiveChangeRef.current?.(normalizeIndex(clamped, n));
+  }
+
+  function slideTo(rawIndex, msSpeed) {
+    goTo(rawIndex, true, msSpeed);
+  }
+
+  function slidePrev() {
+    goTo(s.raw - 1, true);
+  }
+
+  function slideNext() {
+    goTo(s.raw + 1, true);
+  }
+
+  // --- autoplay ------------------------------------------------------------
+
+  function startAutoplay() {
+    stopAutoplay();
+    if (!p().autoplayDelay) return;
+    s.autoplayTimer = setInterval(() => goTo(s.raw + 1, true), p().autoplayDelay);
+  }
+
+  function stopAutoplay() {
+    if (s.autoplayTimer) {
+      clearInterval(s.autoplayTimer);
+      s.autoplayTimer = null;
+    }
+  }
+
+  // --- keyboard (arbitrated by keyboardLock.js via enable/disable) ---------
+
+  function onKeyDown(e) {
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      slidePrev();
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      slideNext();
+    }
+  }
+
+  function enableKeyboard() {
+    if (s.keyboardOn) return;
+    s.keyboardOn = true;
+    window.addEventListener('keydown', onKeyDown);
+  }
+
+  function disableKeyboard() {
+    if (!s.keyboardOn) return;
+    s.keyboardOn = false;
+    window.removeEventListener('keydown', onKeyDown);
+  }
+
+  // --- drag (pointer events; touch-action: none owns the gesture) ----------
+
+  function onPointerDown(e) {
+    if (e.pointerType === 'mouse' && e.button !== 0) return;
+    s.dragging = true;
+    s.pointerId = e.pointerId;
+    s.dragStartX = e.clientX;
+    s.dragOffset = 0;
+    s.lastMoveX = e.clientX;
+    s.lastMoveT = performance.now();
+    s.velocity = 0;
+    // Guarded: synthetic PointerEvents (E2E probes) have no active pointer,
+    // and setPointerCapture would throw NotFoundError for their pointerId.
+    try {
+      track()?.setPointerCapture?.(e.pointerId);
+    } catch {
+      // ignore — the drag still tracks via clientX deltas
+    }
+  }
+
+  function onPointerMove(e) {
+    if (!s.dragging) return;
+    // Gesture ownership (ADR-0007): the carousel owns the drag, so the page
+    // must not scroll from it. preventDefault + touch-action: none (CSS).
+    e.preventDefault();
+    const dx = e.clientX - s.dragStartX;
+    const now = performance.now();
+    s.velocity = (e.clientX - s.lastMoveX) / Math.max(1, now - s.lastMoveT);
+    s.lastMoveX = e.clientX;
+    s.lastMoveT = now;
+    s.dragOffset = dx;
+    const t = track();
+    if (t) t.style.transition = 'none';
+    applyTransforms();
+  }
+
+  function onPointerUp() {
+    if (!s.dragging) return;
+    s.dragging = false;
+    const { mode: m } = p();
+    const step = m === 'cube' ? s.faceWidth : s.step;
+    const snap = dragSnap(s.dragOffset, step, s.velocity);
+    s.dragOffset = 0;
+    s.velocity = 0;
+    goTo(s.raw + snap, true);
+    // Interaction resets the autoplay timer but doesn't stop it
+    // (disableOnInteraction: false — same policy Swiper had).
+    if (s.autoplayTimer) {
+      stopAutoplay();
+      startAutoplay();
+    }
+    try {
+      track()?.releasePointerCapture?.(s.pointerId);
+    } catch {
+      // ignore
+    }
+  }
+
+  function onTransitionEnd(e) {
+    if (e.target !== track()) return;
+    // A settle that crossed a copy boundary: jump 0ms to the equivalent slide
+    // in the adjacent copy (same normalized content → invisible).
+    const { total: n } = p();
+    const target = wrapTarget(s.raw, n);
+    if (target != null) {
+      s.raw = target;
+      const t = track();
+      if (t) {
+        t.style.transition = 'none';
+        applyTransforms();
+      }
+    }
+  }
+
+  // Handlers live in a ref so both the once-mounted listeners and the stable
+  // instance methods call the current closure.
+  const handlersRef = useRef({});
+  handlersRef.current = {
+    measure,
+    applyTransforms,
+    goTo,
+    slideTo,
+    slidePrev,
+    slideNext,
+    startAutoplay,
+    stopAutoplay,
+    enableKeyboard,
+    disableKeyboard,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onTransitionEnd,
+  };
+
+  // The swiper-shaped instance — created once, delegates through handlersRef.
+  if (!instanceRef.current) {
+    instanceRef.current = {
+      get el() {
+        return root();
+      },
+      get slides() {
+        return track() ? Array.from(track().children) : [];
+      },
+      get activeIndex() {
+        return s.raw;
+      },
+      slideTo: (i, ms) => handlersRef.current.slideTo(i, ms),
+      slidePrev: () => handlersRef.current.slidePrev(),
+      slideNext: () => handlersRef.current.slideNext(),
+      keyboard: {
+        enable: () => handlersRef.current.enableKeyboard(),
+        disable: () => handlersRef.current.disableKeyboard(),
+      },
+      autoplay: {
+        start: () => handlersRef.current.startAutoplay(),
+        stop: () => handlersRef.current.stopAutoplay(),
+        resume: () => handlersRef.current.startAutoplay(),
+      },
+    };
+  }
+
+  // Style the track/slides for the current mode + slidesPerView. Called on
+  // mount and whenever the layout-affecting props change (Featuring's
+  // responsive slidesPerView re-sizes the slides; Execom's flat/cube switch
+  // re-positions them).
+  function styleTrack() {
+    const t = track();
+    const r = root();
+    if (!t || !r) return;
+    const { mode: m, slidesPerView: spv, spaceBetween: gap } = p();
+    r.setAttribute('data-carousel-mode', m);
+    // Debug/probe handle (the carousel-probe reads it the way it read
+    // Swiper's __swiper__). Not part of the app contract.
+    r.__carousel__ = instanceRef.current;
+    if (m === 'cube') {
+      r.style.perspective = '1200px';
+      t.style.display = '';
+      t.style.columnGap = '';
+      t.style.transformStyle = 'preserve-3d';
+      Array.from(t.children).forEach((slide) => {
+        slide.style.position = 'absolute';
+        slide.style.inset = '0';
+        slide.style.width = '100%';
+        slide.style.height = '100%';
+        slide.style.backfaceVisibility = 'hidden';
+        slide.style.flex = '';
+      });
+    } else {
+      t.style.display = 'flex';
+      t.style.alignItems = 'center';
+      t.style.columnGap = `${gap}px`;
+      t.style.transformStyle = '';
+      Array.from(t.children).forEach((slide) => {
+        slide.style.position = '';
+        slide.style.inset = '';
+        slide.style.width = '';
+        slide.style.height = '';
+        slide.style.backfaceVisibility = '';
+        slide.style.flex = `0 0 calc((100% - ${gap * (spv - 1)}px) / ${spv})`;
+      });
+    }
+  }
+
+  handlersRef.current.styleTrack = styleTrack;
+
+  // Mount: style the track/slides for the mode, measure, position at the
+  // initial (middle-copy) index, attach listeners. Runs once.
+  useLayoutEffect(() => {
+    const t = track();
+    const r = root();
+    if (!t || !r) return;
+
+    styleTrack();
+    measure();
+    goTo(s.raw, false);
+    applyTransforms();
+
+    t.addEventListener('pointerdown', handlersRef.current.onPointerDown);
+    t.addEventListener('pointermove', handlersRef.current.onPointerMove, { passive: false });
+    t.addEventListener('pointerup', handlersRef.current.onPointerUp);
+    t.addEventListener('pointercancel', handlersRef.current.onPointerUp);
+    t.addEventListener('transitionend', handlersRef.current.onTransitionEnd);
+    const onResize = () => {
+      handlersRef.current.measure();
+      handlersRef.current.applyTransforms();
+    };
+    window.addEventListener('resize', onResize);
+
+    return () => {
+      stopAutoplay();
+      disableKeyboard();
+      t.removeEventListener('pointerdown', handlersRef.current.onPointerDown);
+      t.removeEventListener('pointermove', handlersRef.current.onPointerMove);
+      t.removeEventListener('pointerup', handlersRef.current.onPointerUp);
+      t.removeEventListener('pointercancel', handlersRef.current.onPointerUp);
+      t.removeEventListener('transitionend', handlersRef.current.onTransitionEnd);
+      window.removeEventListener('resize', onResize);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Re-style when the layout-affecting props change (e.g. Featuring's
+  // responsive slidesPerView) without re-attaching listeners. Only refs are
+  // touched, so the dep array is exactly the layout-affecting props.
+  useEffect(() => {
+    handlersRef.current.styleTrack();
+    handlersRef.current.measure();
+    handlersRef.current.applyTransforms();
+  }, [slidesPerView, spaceBetween, mode, total]);
+
+  return { instanceRef, trackRef };
+}

--- a/src/hooks/useCarousel.js
+++ b/src/hooks/useCarousel.js
@@ -99,6 +99,10 @@ export default function useCarousel({
       const firstCard = t.firstElementChild?.firstElementChild;
       const h = firstCard ? firstCard.offsetHeight : 0;
       if (h) t.style.height = `${h}px`;
+      // Face transforms depend only on each index and the measured face width
+      // — neither changes during a drag, so write them once here (NOT in the
+      // pointermove hot path, which only re-rotates the track).
+      applyFaceTransforms();
     } else {
       const first = t.firstElementChild;
       s.slideWidth = first ? first.getBoundingClientRect().width : 0;
@@ -120,14 +124,22 @@ export default function useCarousel({
     });
   }
 
+  // Cube faces: rotateY(i * 90°) translateZ(radius). Written from measure /
+  // styleTrack (index + faceWidth only) — kept out of applyTransforms so a
+  // pointer drag re-rotates the track without rewriting all faces every move.
+  function applyFaceTransforms() {
+    const t = track();
+    if (!t || p().mode !== 'cube') return;
+    Array.from(t.children).forEach((slide, i) => {
+      slide.style.transform = cubeFaceTransform(i, s.faceWidth / 2);
+    });
+  }
+
   function applyTransforms() {
     const t = track();
     if (!t) return;
     const { mode: m } = p();
     if (m === 'cube') {
-      Array.from(t.children).forEach((slide, i) => {
-        slide.style.transform = cubeFaceTransform(i, s.faceWidth / 2);
-      });
       t.style.transform = cubeTrackTransform(
         s.raw,
         s.dragging ? cubeDragAngle(s.dragOffset, s.faceWidth) : 0,
@@ -249,6 +261,17 @@ export default function useCarousel({
   function onPointerUp() {
     if (!s.dragging) return;
     s.dragging = false;
+    // Release the capture BEFORE the settle animation starts, so the browser
+    // stops delivering move events to a track that is about to animate.
+    const pid = s.pointerId;
+    try {
+      track()?.releasePointerCapture?.(pid);
+    } catch {
+      // ignore
+    }
+    // Clear the stored id — a later pointercancel for a different pointer
+    // must not release a stale capture.
+    s.pointerId = null;
     const { mode: m } = p();
     const step = m === 'cube' ? s.faceWidth : s.step;
     const snap = dragSnap(s.dragOffset, step, s.velocity);
@@ -260,11 +283,6 @@ export default function useCarousel({
     if (s.autoplayTimer) {
       stopAutoplay();
       startAutoplay();
-    }
-    try {
-      track()?.releasePointerCapture?.(s.pointerId);
-    } catch {
-      // ignore
     }
   }
 
@@ -357,11 +375,16 @@ export default function useCarousel({
         slide.style.backfaceVisibility = 'hidden';
         slide.style.flex = '';
       });
+      applyFaceTransforms();
     } else {
       t.style.display = 'flex';
       t.style.alignItems = 'center';
       t.style.columnGap = `${gap}px`;
       t.style.transformStyle = '';
+      // Clear the cube-mode scaffolding: a flat fallback must not keep the
+      // cube's pinned pixel height or perspective when mode switches.
+      t.style.height = '';
+      r.style.perspective = '';
       Array.from(t.children).forEach((slide) => {
         slide.style.position = '';
         slide.style.inset = '';
@@ -392,15 +415,23 @@ export default function useCarousel({
     t.addEventListener('pointerup', handlersRef.current.onPointerUp);
     t.addEventListener('pointercancel', handlersRef.current.onPointerUp);
     t.addEventListener('transitionend', handlersRef.current.onTransitionEnd);
+    // rAF-throttled: a drag-resize fires resize dozens of times per second,
+    // and measure() forces layout — coalesce to at most one per frame.
+    let resizeRaf = 0;
     const onResize = () => {
-      handlersRef.current.measure();
-      handlersRef.current.applyTransforms();
+      if (resizeRaf) return;
+      resizeRaf = requestAnimationFrame(() => {
+        resizeRaf = 0;
+        handlersRef.current.measure();
+        handlersRef.current.applyTransforms();
+      });
     };
     window.addEventListener('resize', onResize);
 
     return () => {
       stopAutoplay();
       disableKeyboard();
+      if (resizeRaf) cancelAnimationFrame(resizeRaf);
       t.removeEventListener('pointerdown', handlersRef.current.onPointerDown);
       t.removeEventListener('pointermove', handlersRef.current.onPointerMove);
       t.removeEventListener('pointerup', handlersRef.current.onPointerUp);
@@ -413,8 +444,15 @@ export default function useCarousel({
 
   // Re-style when the layout-affecting props change (e.g. Featuring's
   // responsive slidesPerView) without re-attaching listeners. Only refs are
-  // touched, so the dep array is exactly the layout-affecting props.
+  // touched, so the dep array is exactly the layout-affecting props. The
+  // mount run is skipped — the layout effect above already did the initial
+  // styleTrack/measure/applyTransforms on first paint.
+  const mountedRef = useRef(false);
   useEffect(() => {
+    if (!mountedRef.current) {
+      mountedRef.current = true;
+      return;
+    }
     handlersRef.current.styleTrack();
     handlersRef.current.measure();
     handlersRef.current.applyTransforms();

--- a/src/hooks/useCarousel.js
+++ b/src/hooks/useCarousel.js
@@ -225,6 +225,9 @@ export default function useCarousel({
   // --- drag (pointer events; touch-action: none owns the gesture) ----------
 
   function onPointerDown(e) {
+    // Only the first pointer owns the drag — a second finger (or a stray
+    // pointer) must not overwrite s.pointerId and hijack the gesture.
+    if (s.dragging) return;
     if (e.pointerType === 'mouse' && e.button !== 0) return;
     s.dragging = true;
     s.pointerId = e.pointerId;
@@ -243,7 +246,9 @@ export default function useCarousel({
   }
 
   function onPointerMove(e) {
-    if (!s.dragging) return;
+    // Ignore moves from any pointer that is not the one that started the
+    // drag (multi-touch: only the owning pointer moves the carousel).
+    if (!s.dragging || e.pointerId !== s.pointerId) return;
     // Gesture ownership (ADR-0007): the carousel owns the drag, so the page
     // must not scroll from it. preventDefault + touch-action: none (CSS).
     e.preventDefault();
@@ -258,8 +263,10 @@ export default function useCarousel({
     applyTransforms();
   }
 
-  function onPointerUp() {
-    if (!s.dragging) return;
+  function onPointerUp(e) {
+    // Only the owning pointer may end the drag (also fired for pointercancel,
+    // which carries the same pointerId).
+    if (!s.dragging || e.pointerId !== s.pointerId) return;
     s.dragging = false;
     // Release the capture BEFORE the settle animation starts, so the browser
     // stops delivering move events to a track that is about to animate.

--- a/src/utils/aosGating.js
+++ b/src/utils/aosGating.js
@@ -9,6 +9,11 @@
 // never reached AOS). Precedence when contradictory overrides are both set
 // (?perf=slow&motion=on): the perf override wins — it is the "degrade
 // everything" hammer, and lowPower is part of its resolved profile.
+//
+// This module is the pure-decision owner (ADR-0009): gating, init policy and
+// the viewport failsafe *decisions* live here. The failsafe's browser
+// lifecycle (listeners, rAF, cleanup) lives in the useAosFailsafe hook, which
+// is mounted once in App.
 import detectProfile from './detectProfile.js';
 import AOS from 'aos';
 
@@ -26,86 +31,52 @@ export function aosDisabled() {
 // [data-aos] content (including anything mounted later, e.g. lazy routes).
 // Gate + init live here so the 'aos' dependency and the override handling have
 // a single owner (the old second copy of the gate checks lived in App.jsx).
-// The app-lifetime watch started by initAOS on capable devices (module-level
-// so it can be torn down in tests / HMR without leaving orphan listeners).
-let failsafeCleanup = null;
-
 export function initAOS() {
   const gated = aosDisabled();
   if (document.body) {
     document.body.classList.toggle('aos-disabled', gated);
   }
-  AOS.init({ once: true, disable: gated });
-  // Capable devices are guarded by the viewport failsafe (AOS JS can break
-  // or miss an element — content must never stay hidden). Gated devices are
-  // already covered by the body.aos-disabled CSS net, which force-shows
-  // everything, so the JS watch would be redundant there.
-  failsafeCleanup?.();
-  failsafeCleanup = gated ? null : startAosFailsafe();
+  // AOS.init must never take the app down: if it throws at module scope the
+  // whole page would fail to boot. On capable devices the viewport failsafe
+  // (useAosFailsafe) force-shows in-view content anyway; on gated devices the
+  // body.aos-disabled CSS net covers everything.
+  try {
+    AOS.init({ once: true, disable: gated });
+  } catch (error) {
+    console.error('AOS initialization failed; the viewport failsafe will cover reveals.', error);
+  }
   return gated;
 }
 
-// Teardown for the watch initAOS started (specs / HMR).
-export function stopAosFailsafe() {
-  failsafeCleanup?.();
-  failsafeCleanup = null;
-}
-
-// --- AOS failsafe -----------------------------------------------------------
+// --- AOS failsafe decisions ------------------------------------------------
 //
 // The gate net above covers gated devices, but on a CAPABLE device the only
 // thing that ever reveals [data-aos] content is AOS's own scroll observer.
 // If AOS's JS breaks, throws, or misses an element (a race with a lazy
 // chunk's MutationObserver), visible content can stay opacity:0 forever.
 //
-// This backstop is the scroll-into-view equivalent the site already has for
-// gated devices: whenever a [data-aos] element is inside the viewport and
-// still lacks .aos-animate, force-show it. It only touches what is actually
-// on screen, so below-the-fold scroll reveals are untouched when AOS works,
-// and nothing can remain hidden when AOS doesn't.
+// The backstop (started by the useAosFailsafe hook) is the scroll-into-view
+// equivalent the site already has for gated devices: whenever a [data-aos]
+// element is inside the viewport and still lacks .aos-animate, force-show it.
+// It only touches what is actually on screen, so below-the-fold scroll
+// reveals are untouched when AOS works, and nothing can remain hidden when
+// AOS doesn't. The *decisions* are pure — no DOM listeners or lifecycle here.
 
 // Pure decision: should this element be force-shown right now? (In the
 // viewport, carries data-aos, and AOS never revealed it.)
-export function shouldForceShowAos(el, viewportHeight = window.innerHeight) {
+export function shouldForceShowAos(el, viewportHeight) {
   if (!el || el.classList.contains('aos-animate') || !el.hasAttribute('data-aos')) return false;
+  // Resolve the viewport height only after the element guards, so a
+  // server-side call (no window) returns false instead of throwing.
+  const height = viewportHeight ?? (typeof window === 'undefined' ? 0 : window.innerHeight);
   const r = el.getBoundingClientRect();
-  return r.bottom > 0 && r.top < viewportHeight;
+  return r.bottom > 0 && r.top < height;
 }
 
 // Pure list: every [data-aos] element in the viewport that AOS left hidden.
-export function stuckAosInView(viewportHeight = window.innerHeight) {
+export function stuckAosInView(viewportHeight) {
   if (typeof document === 'undefined') return [];
   return Array.from(document.querySelectorAll('[data-aos]')).filter((el) =>
     shouldForceShowAos(el, viewportHeight),
   );
-}
-
-/**
- * Start the failsafe watch: on scroll/resize (rAF-throttled, passive), force
- * .aos-animate onto any in-view [data-aos] element AOS left hidden. Returns a
- * cleanup handle. The initial run covers elements already in view at boot.
- */
-export function startAosFailsafe() {
-  if (typeof window === 'undefined' || typeof document === 'undefined') return () => {};
-
-  let rafId = 0;
-  const forceShow = () => {
-    stuckAosInView().forEach((el) => el.classList.add('aos-animate'));
-  };
-  const schedule = () => {
-    if (rafId) return;
-    rafId = requestAnimationFrame(() => {
-      rafId = 0;
-      forceShow();
-    });
-  };
-  window.addEventListener('scroll', schedule, { passive: true });
-  window.addEventListener('resize', schedule);
-  forceShow(); // elements already in the viewport at boot
-
-  return () => {
-    if (rafId) cancelAnimationFrame(rafId);
-    window.removeEventListener('scroll', schedule);
-    window.removeEventListener('resize', schedule);
-  };
 }

--- a/src/utils/aosGating.js
+++ b/src/utils/aosGating.js
@@ -26,11 +26,86 @@ export function aosDisabled() {
 // [data-aos] content (including anything mounted later, e.g. lazy routes).
 // Gate + init live here so the 'aos' dependency and the override handling have
 // a single owner (the old second copy of the gate checks lived in App.jsx).
+// The app-lifetime watch started by initAOS on capable devices (module-level
+// so it can be torn down in tests / HMR without leaving orphan listeners).
+let failsafeCleanup = null;
+
 export function initAOS() {
   const gated = aosDisabled();
   if (document.body) {
     document.body.classList.toggle('aos-disabled', gated);
   }
   AOS.init({ once: true, disable: gated });
+  // Capable devices are guarded by the viewport failsafe (AOS JS can break
+  // or miss an element — content must never stay hidden). Gated devices are
+  // already covered by the body.aos-disabled CSS net, which force-shows
+  // everything, so the JS watch would be redundant there.
+  failsafeCleanup?.();
+  failsafeCleanup = gated ? null : startAosFailsafe();
   return gated;
+}
+
+// Teardown for the watch initAOS started (specs / HMR).
+export function stopAosFailsafe() {
+  failsafeCleanup?.();
+  failsafeCleanup = null;
+}
+
+// --- AOS failsafe -----------------------------------------------------------
+//
+// The gate net above covers gated devices, but on a CAPABLE device the only
+// thing that ever reveals [data-aos] content is AOS's own scroll observer.
+// If AOS's JS breaks, throws, or misses an element (a race with a lazy
+// chunk's MutationObserver), visible content can stay opacity:0 forever.
+//
+// This backstop is the scroll-into-view equivalent the site already has for
+// gated devices: whenever a [data-aos] element is inside the viewport and
+// still lacks .aos-animate, force-show it. It only touches what is actually
+// on screen, so below-the-fold scroll reveals are untouched when AOS works,
+// and nothing can remain hidden when AOS doesn't.
+
+// Pure decision: should this element be force-shown right now? (In the
+// viewport, carries data-aos, and AOS never revealed it.)
+export function shouldForceShowAos(el, viewportHeight = window.innerHeight) {
+  if (!el || el.classList.contains('aos-animate') || !el.hasAttribute('data-aos')) return false;
+  const r = el.getBoundingClientRect();
+  return r.bottom > 0 && r.top < viewportHeight;
+}
+
+// Pure list: every [data-aos] element in the viewport that AOS left hidden.
+export function stuckAosInView(viewportHeight = window.innerHeight) {
+  if (typeof document === 'undefined') return [];
+  return Array.from(document.querySelectorAll('[data-aos]')).filter((el) =>
+    shouldForceShowAos(el, viewportHeight),
+  );
+}
+
+/**
+ * Start the failsafe watch: on scroll/resize (rAF-throttled, passive), force
+ * .aos-animate onto any in-view [data-aos] element AOS left hidden. Returns a
+ * cleanup handle. The initial run covers elements already in view at boot.
+ */
+export function startAosFailsafe() {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return () => {};
+
+  let rafId = 0;
+  const forceShow = () => {
+    stuckAosInView().forEach((el) => el.classList.add('aos-animate'));
+  };
+  const schedule = () => {
+    if (rafId) return;
+    rafId = requestAnimationFrame(() => {
+      rafId = 0;
+      forceShow();
+    });
+  };
+  window.addEventListener('scroll', schedule, { passive: true });
+  window.addEventListener('resize', schedule);
+  forceShow(); // elements already in the viewport at boot
+
+  return () => {
+    if (rafId) cancelAnimationFrame(rafId);
+    window.removeEventListener('scroll', schedule);
+    window.removeEventListener('resize', schedule);
+  };
 }

--- a/src/utils/carouselGeometry.js
+++ b/src/utils/carouselGeometry.js
@@ -1,0 +1,62 @@
+// Carousel geometry — the transform math for the hand-rolled carousels
+// (Featuring's flat slider and Execom's 3D cube), replacing Swiper's
+// internal layout engine with pure, unit-tested functions.
+//
+// Both carousels render 3 copies of the slides for the seamless wrap (see
+// carouselWrap.js) and move a single "track" element:
+//   - flat:  translate3d(-activeIndex * step, 0, 0)
+//   - cube:  each face rotateY(i * 90deg) translateZ(radius); the track
+//            rotateY(-activeIndex * 90deg) — the classic CSS cube, matching
+//            Swiper's EffectCube orientation (shadow: false — the repo's
+//            Execom config, they read as a black smear on the dark bg).
+//
+// All functions are pure: no DOM, no state.
+
+export const CUBE_ANGLE = 90; // the cube rotates 90° per face
+
+// Horizontal distance between two flat slide positions (slide width + gap).
+export function slideStep(slideWidth, spaceBetween) {
+  return slideWidth + spaceBetween;
+}
+
+// Track transform for the flat slider. dragOffset lets a pointer drag
+// preview the motion (0 when idle).
+export function flatTrackTransform(activeIndex, step, dragOffset = 0) {
+  return `translate3d(${-(activeIndex * step) + dragOffset}px, 0, 0)`;
+}
+
+// One cube face: rotated to its angle, pushed out to the cube radius
+// (half the track width). Faces are absolutely positioned (CSS), so the
+// transform-origin is the face center.
+export function cubeFaceTransform(index, radius) {
+  return `rotateY(${index * CUBE_ANGLE}deg) translateZ(${radius}px)`;
+}
+
+// The cube track: rotate the whole cube by -90° per active face. dragAngle
+// (degrees, from a pointer drag) previews the motion when non-zero.
+export function cubeTrackTransform(activeIndex, dragAngle = 0) {
+  return `rotateY(${-(activeIndex * CUBE_ANGLE + dragAngle)}deg)`;
+}
+
+// A pointer delta (px) converted to cube drag degrees: a full face width of
+// travel = one 90° face turn.
+export function cubeDragAngle(deltaX, faceWidth) {
+  if (!faceWidth) return 0;
+  return (deltaX / faceWidth) * CUBE_ANGLE;
+}
+
+// Snap decision after a drag: which way should the carousel settle?
+//   deltaX — total horizontal pointer travel (negative = dragged left)
+//   step   — one slide's worth of travel (flat: slideStep; cube: faceWidth)
+//   velocity — px per ms of the final gesture (flick detection)
+//   thresholdRatio — fraction of `step` that forces a turn (default 1/3)
+// Returns -1 (previous), 1 (next) or 0 (snap back in place).
+export function dragSnap(deltaX, step, velocity, thresholdRatio = 1 / 3) {
+  const threshold = step * thresholdRatio;
+  // Flick beats distance: a fast swipe overrides a short drag.
+  const FLICK_PX_PER_MS = 0.5;
+  if (Math.abs(velocity) > FLICK_PX_PER_MS) return velocity < 0 ? 1 : -1;
+  if (deltaX < -threshold) return 1;
+  if (deltaX > threshold) return -1;
+  return 0;
+}

--- a/src/utils/carouselGeometry.js
+++ b/src/utils/carouselGeometry.js
@@ -33,9 +33,14 @@ export function cubeFaceTransform(index, radius) {
 }
 
 // The cube track: rotate the whole cube by -90° per active face. dragAngle
-// (degrees, from a pointer drag) previews the motion when non-zero.
+// (degrees, from a pointer drag) previews the motion when non-zero: the base
+// rotation is negative (faces advance left), so a NEGATIVE dragAngle (finger
+// dragging left) must push it further negative — toward the next face, the
+// same direction dragSnap settles on. Adding the angle inside the negation
+// would invert the preview (drag left → previous face flashes, then the cube
+// jumps forward on release).
 export function cubeTrackTransform(activeIndex, dragAngle = 0) {
-  return `rotateY(${-(activeIndex * CUBE_ANGLE + dragAngle)}deg)`;
+  return `rotateY(${-activeIndex * CUBE_ANGLE + dragAngle}deg)`;
 }
 
 // A pointer delta (px) converted to cube drag degrees: a full face width of
@@ -53,9 +58,14 @@ export function cubeDragAngle(deltaX, faceWidth) {
 // Returns -1 (previous), 1 (next) or 0 (snap back in place).
 export function dragSnap(deltaX, step, velocity, thresholdRatio = 1 / 3) {
   const threshold = step * thresholdRatio;
-  // Flick beats distance: a fast swipe overrides a short drag.
+  // Flick beats distance — but only once the finger actually travelled. A
+  // stationary tap's micro-jitter reports a huge velocity (px / ms with
+  // ms→0), which would otherwise turn a face the user meant as a tap.
   const FLICK_PX_PER_MS = 0.5;
-  if (Math.abs(velocity) > FLICK_PX_PER_MS) return velocity < 0 ? 1 : -1;
+  const FLICK_MIN_PX = 10;
+  if (Math.abs(velocity) > FLICK_PX_PER_MS && Math.abs(deltaX) > FLICK_MIN_PX) {
+    return velocity < 0 ? 1 : -1;
+  }
   if (deltaX < -threshold) return 1;
   if (deltaX > threshold) return -1;
   return 0;

--- a/src/utils/carouselWrap.js
+++ b/src/utils/carouselWrap.js
@@ -1,15 +1,16 @@
 // Seamless infinite wrap for the duplicated-slide carousels (Execom's
 // TeamCarousel and the Featuring ECHO carousel): 3 copies of the slides are
-// rendered because Swiper's loop mode can't be used (the cube rotates 90° per
-// face, and loop jams at its append boundary with only ~3 slides per view). A
-// 0ms jump between copies makes the wrap invisible — index 0 and 32 share the
-// same cube orientation. Pure math, unit-tested. Used to live in
-// src/Components/Execom/ until Featuring grew the same pattern.
+// rendered because the cube rotates 90° per face and a true loop would need
+// unbounded copies — a 0ms jump between copies makes the wrap invisible
+// (index 0 and 32 share the same cube orientation). Pure math, unit-tested.
+// Used to live in src/Components/Execom/ until Featuring grew the same
+// pattern. The carousels are hand-rolled (see useCarousel) — this module
+// only answers "where am I / where do I jump".
 export function normalizeIndex(activeIndex, total) {
   return activeIndex % total;
 }
 
-// The copy-jump target for a raw swiper index, or null when it sits in the
+// The copy-jump target for a raw carousel index, or null when it sits in the
 // middle copy (indices total..2*total-1) and no jump is needed.
 export function wrapTarget(activeIndex, total) {
   if (activeIndex >= total * 2) return activeIndex - total;

--- a/src/utils/keyboardLock.js
+++ b/src/utils/keyboardLock.js
@@ -104,11 +104,13 @@ export function subscribeKeyboardArbitration(fn) {
 }
 
 // Carousels call this whenever ownership may have changed (focus, scroll,
-// interaction) to enable/disable their Swiper keyboard.
-export function syncCarouselKeyboard(swiper, ownId) {
-  if (!swiper?.keyboard) return;
-  if (getArrowOwner() === ownId) swiper.keyboard.enable();
-  else swiper.keyboard.disable();
+// interaction) to enable/disable their keyboard. The `carousel` is the
+// useCarousel instance — it exposes the same keyboard.enable/disable shape
+// the old Swiper instances did, so this seam is unchanged.
+export function syncCarouselKeyboard(carousel, ownId) {
+  if (!carousel?.keyboard) return;
+  if (getArrowOwner() === ownId) carousel.keyboard.enable();
+  else carousel.keyboard.disable();
 }
 
 // True when an element's box intersects the viewport (with an optional

--- a/tests/carousel-lazy.spec.js
+++ b/tests/carousel-lazy.spec.js
@@ -1,15 +1,14 @@
 import { test, expect } from '@playwright/test';
 import { gotoHome } from './helpers';
 
-// Regression guard for the ScrollGate boot win: the Swiper sections
+// Regression guard for the ScrollGate boot win: the carousel sections
 // (Featuring + Execom) must NOT mount — and their chunk must not be fetched
-// as a script — on first load, or the 312ms swiper-vendor boot eval comes
-// back. They must mount when the user scrolls to them.
-test.describe('Swiper boot deferral (ScrollGate)', () => {
+// as a script — on first load. They must mount when the user scrolls to them.
+test.describe('Carousel boot deferral (ScrollGate)', () => {
   test('Featuring + Execom stay unmounted at boot, mount after scrolling', async ({ page }) => {
     await gotoHome(page);
 
-    // Behavioral: no swiper content in the DOM at boot. The ScrollGate
+    // Behavioral: no carousel content in the DOM at boot. The ScrollGate
     // wrapper carries the section id, so the section itself is the signal.
     const bootState = await page.evaluate(() => ({
       featuringMounted: !!document.querySelector('#featuring .feat-swiper'),
@@ -18,21 +17,23 @@ test.describe('Swiper boot deferral (ScrollGate)', () => {
       ),
       // Script-initiator resources only — the service worker's background
       // precache fetch shows up as initiatorType 'fetch'/'other', so this
-      // ignores it and checks only real dynamic-import script loads.
-      swiperScripts: performance
+      // ignores it and checks only real dynamic-import script loads. The
+      // carousel sections ship their own lazy chunks (Featuring/Execom);
+      // those must not be fetched at boot.
+      carouselScripts: performance
         .getEntriesByType('resource')
-        .filter((r) => r.initiatorType === 'script' && /swiper/.test(r.name)).length,
+        .filter((r) => r.initiatorType === 'script' && /(Featuring|Execom)/.test(r.name)).length,
     }));
     expect(bootState.featuringMounted).toBe(false);
     expect(bootState.execomMounted).toBe(false);
-    expect(bootState.swiperScripts).toBe(0);
+    expect(bootState.carouselScripts).toBe(0);
 
-    // Scroll Featuring into view → the gate opens → chunk loads → swiper mounts.
+    // Scroll Featuring into view → the gate opens → chunk loads → carousel mounts.
     await page.locator('#featuring').scrollIntoViewIfNeeded();
     await expect(page.locator('#featuring .feat-swiper')).toBeVisible({ timeout: 10000 });
 
     // Scroll Execom into view → it mounts too. Both TeamCarousel variants
-    // (desktop swiper + mobile cube) stay in the DOM with CSS hiding the
+    // (desktop cube + mobile cube) stay in the DOM with CSS hiding the
     // inactive one, so match the variant that is actually visible.
     await page.locator('#execom').scrollIntoViewIfNeeded();
     await expect(

--- a/tests/carousels.spec.js
+++ b/tests/carousels.spec.js
@@ -134,6 +134,38 @@ test.describe('Execom mobile cube drag', () => {
     await expect.poll(activeIndex, { timeout: 5000 }).not.toBe(before);
   });
 
+  test('every member shows on the front face as the cube advances (3-copy overlap is class-gated)', async ({
+    page,
+  }) => {
+    await gotoHome(page);
+    await page.locator('#execom').scrollIntoViewIfNeeded();
+    await page.locator('.execom-cube-swiper[data-carousel-ready]').waitFor({
+      state: 'attached',
+    });
+
+    // The 3 copies of 11 slides share the four cube faces (children i, i±4,
+    // ... sit at the same angle) — the class-gated visibility CSS decides
+    // which child actually shows. Walk every logical member and read the
+    // visible (active) member each step to prove the correct one is always
+    // front-facing.
+    const seen = await page.evaluate(async () => {
+      const swiper = document.querySelector('.execom-cube-swiper');
+      const inst = swiper.__carousel__;
+      inst.autoplay.stop(); // the on-screen autoplay timer must not skip a step mid-walk
+      const out = [];
+      for (let i = 0; i < 11; i++) {
+        const active = swiper.querySelector('.swiper-slide-active img');
+        out.push(active ? active.alt : null);
+        inst.slideNext();
+        await new Promise((r) => setTimeout(r, 250)); // settle the rotation
+      }
+      return out;
+    });
+    // All 11 distinct members, in roster order (the wrap repeats content).
+    expect(new Set(seen).size).toBe(11);
+    expect(seen.every((name) => typeof name === 'string' && name.length > 0)).toBe(true);
+  });
+
   test('rotating the cube never scrolls the page (touch-action none + preventDefault)', async ({
     page,
   }) => {

--- a/tests/carousels.spec.js
+++ b/tests/carousels.spec.js
@@ -148,7 +148,11 @@ test.describe('Execom mobile cube drag', () => {
     // which child actually shows. Walk every logical member and read the
     // visible (active) member each step to prove the correct one is always
     // front-facing.
-    const seen = await page.evaluate(async () => {
+    // The active class toggles synchronously inside slideNext (no transition
+    // or settle needed for the read) — keeping this synchronous makes the
+    // walk deterministic across device profiles instead of racing a fixed
+    // timeout.
+    const seen = await page.evaluate(() => {
       const swiper = document.querySelector('.execom-cube-swiper');
       const inst = swiper.__carousel__;
       inst.autoplay.stop(); // the on-screen autoplay timer must not skip a step mid-walk
@@ -157,7 +161,6 @@ test.describe('Execom mobile cube drag', () => {
         const active = swiper.querySelector('.swiper-slide-active img');
         out.push(active ? active.alt : null);
         inst.slideNext();
-        await new Promise((r) => setTimeout(r, 250)); // settle the rotation
       }
       return out;
     });

--- a/tests/carousels.spec.js
+++ b/tests/carousels.spec.js
@@ -42,9 +42,9 @@ test.describe('Featuring carousel', () => {
 });
 
 test.describe('Execom / Meet the team carousel', () => {
-  // The Swiper-based team carousel only mounts on desktop (mobile renders a
-  // static grid with the cube disabled), so its interactions are desktop-only.
-  test.skip(({ isMobile }) => isMobile, 'team carousel only mounts on desktop');
+  // The Execom carousel runs both a desktop and a mobile variant; the mobile
+  // cube is hidden on desktop (CSS), so these interactions are desktop-only.
+  test.skip(({ isMobile }) => isMobile, 'team carousel interactions are desktop-only');
 
   test.beforeEach(async ({ page }) => {
     await gotoHome(page);
@@ -60,8 +60,8 @@ test.describe('Execom / Meet the team carousel', () => {
     );
 
   test('dot indicator navigates the team carousel', async ({ page }) => {
-    // Both cube and flat modes render the custom 11-dot indicator (Swiper's
-    // loop + pagination were replaced by duplicated slides + wrap).
+    // Both cube and flat modes render the custom 11-dot indicator (the
+    // 3-copy wrap replaces a true loop, so the dots are hand-rolled).
     const before = await activeIndex(page);
     await page.locator('.execom-swiper + div button[aria-label]').nth(2).click();
     await expect.poll(() => activeIndex(page), { timeout: 5000 }).not.toBe(before);
@@ -80,8 +80,8 @@ test.describe('Execom / Meet the team carousel', () => {
   test('arrow keys still work after clicking a dot (dots are part of the widget)', async ({
     page,
   }) => {
-    // The dots sit OUTSIDE the swiper element (direct sibling). If the widget
-    // boundary were the swiper alone, focusing a dot would withhold the arrow
+    // The dots sit OUTSIDE the carousel root (direct sibling). If the widget
+    // boundary were the root alone, focusing a dot would withhold the arrow
     // keys from the carousel. Click a dot, then verify arrows still advance.
     await page.locator('.execom-swiper + div button[aria-label]').nth(3).click();
     await page.waitForTimeout(300);
@@ -129,20 +129,19 @@ test.describe('Execom mobile cube drag', () => {
     await expect.poll(activeIndex, { timeout: 5000 }).not.toBe(before);
   });
 
-  test('rotating the cube never scrolls the page (touch-action none + Swiper preventDefault)', async ({
+  test('rotating the cube never scrolls the page (touch-action none + preventDefault)', async ({
     page,
   }) => {
     await gotoHome(page);
     await page.locator('#execom').scrollIntoViewIfNeeded();
     await page.waitForTimeout(800);
 
-    // A real phone fires pointer events for a touch drag — Swiper v14 only
-    // drives its gesture from pointer events (its touchstart handler just
-    // records the touchId and returns), so synthetic PointerEvents are the
-    // faithful stand-in. The swiper must own the gesture (computed
-    // touch-action none, overriding Swiper's pan-y) and Swiper must engage
-    // and preventDefault the horizontal drag — either alone would let a
-    // diagonal drag scroll the page mid-rotation.
+    // A real phone fires pointer events for a touch drag — the hand-rolled
+    // carousel drives its gesture entirely from pointer events, so synthetic
+    // PointerEvents are the faithful stand-in. The cube must own the gesture
+    // (computed touch-action none) and the hook must engage and preventDefault
+    // the horizontal drag — either alone would let a diagonal drag scroll the
+    // page mid-rotation.
     const result = await page.evaluate(() => {
       const swiper = document.querySelector('.execom-cube-swiper');
       const slide =

--- a/tests/carousels.spec.js
+++ b/tests/carousels.spec.js
@@ -109,7 +109,12 @@ test.describe('Execom mobile cube drag', () => {
   test('dragging the cube advances to the next member', async ({ page }) => {
     await gotoHome(page);
     await page.locator('#execom').scrollIntoViewIfNeeded();
-    await page.waitForTimeout(800);
+    // The cube is only interactive once the hook applied the first transforms
+    // — wait for the readiness signal instead of a fixed sleep, so slow/low-
+    // power profiles can't flake the test.
+    await page.locator('.execom-cube-swiper[data-carousel-ready]').waitFor({
+      state: 'attached',
+    });
 
     const activeIndex = () =>
       page.evaluate(() =>
@@ -134,7 +139,9 @@ test.describe('Execom mobile cube drag', () => {
   }) => {
     await gotoHome(page);
     await page.locator('#execom').scrollIntoViewIfNeeded();
-    await page.waitForTimeout(800);
+    await page.locator('.execom-cube-swiper[data-carousel-ready]').waitFor({
+      state: 'attached',
+    });
 
     // A real phone fires pointer events for a touch drag — the hand-rolled
     // carousel drives its gesture entirely from pointer events, so synthetic

--- a/tests/unit/aosGating.spec.js
+++ b/tests/unit/aosGating.spec.js
@@ -4,8 +4,6 @@ import {
   initAOS,
   shouldForceShowAos,
   stuckAosInView,
-  startAosFailsafe,
-  stopAosFailsafe,
 } from '../../src/utils/aosGating.js';
 
 vi.mock('aos', () => ({ default: { init: vi.fn() } }));
@@ -131,17 +129,31 @@ describe('initAOS — gate + init in one owner', () => {
       else delete document.body;
     }
   });
+
+  it('survives AOS.init throwing — the app must boot and the failsafe still covers reveals', () => {
+    // AOS.init runs at module scope; a throw there would take the whole app
+    // down. Catch it, keep the body tag, and return the gate so callers know
+    // (the viewport failsafe in useAosFailsafe force-shows in-view content).
+    const err = new Error('AOS broke');
+    AOS.init.mockImplementation(() => {
+      throw err;
+    });
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      expect(() => initAOS()).not.toThrow();
+      expect(initAOS()).toBe(false);
+      expect(document.body.classList.contains('aos-disabled')).toBe(false);
+      expect(console.error).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
 });
 
-describe('AOS failsafe — content can never stay hidden on capable devices', () => {
+describe('AOS failsafe decisions — pure viewport math', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
     document.body.classList.remove('aos-disabled');
-    stopAosFailsafe(); // clear any watch an initAOS test left running
-  });
-
-  afterEach(() => {
-    stopAosFailsafe();
   });
 
   const addStuck = (id, top, height = 100) => {
@@ -155,11 +167,9 @@ describe('AOS failsafe — content can never stay hidden on capable devices', ()
     return el;
   };
 
-  it('force-shows a [data-aos] element that is in the viewport but lacks .aos-animate', () => {
+  it('identifies a [data-aos] element that is in the viewport but lacks .aos-animate', () => {
     const el = addStuck('in-view', 100);
     expect(shouldForceShowAos(el, 800)).toBe(true);
-    startAosFailsafe();
-    expect(el.classList.contains('aos-animate')).toBe(true);
   });
 
   it('leaves below-the-fold elements hidden (AOS still owns the scroll reveal)', () => {
@@ -184,13 +194,17 @@ describe('AOS failsafe — content can never stay hidden on capable devices', ()
     expect(inView.classList.contains('aos-animate')).toBe(false);
   });
 
-  it('the cleanup handle detaches the listeners (no force-show after cleanup)', () => {
-    const cleanup = startAosFailsafe();
-    cleanup();
-    // Added AFTER the watch started and stopped: the boot run never saw it,
-    // and a synthetic scroll must not reveal it either.
-    const el = addStuck('in-view', 100);
-    window.dispatchEvent(new Event('scroll'));
-    expect(el.classList.contains('aos-animate')).toBe(false);
+  it('does not read window in default parameters (server-side calls return [] instead of throwing)', () => {
+    // shouldForceShowAos/stuckAosInView must not touch window before the
+    // environment guard — a SSR call used to throw ReferenceError at the
+    // default-parameter evaluation.
+    const savedWindow = globalThis.window;
+    delete globalThis.window;
+    try {
+      expect(shouldForceShowAos(null, undefined)).toBe(false);
+      expect(stuckAosInView()).toEqual([]);
+    } finally {
+      globalThis.window = savedWindow;
+    }
   });
 });

--- a/tests/unit/aosGating.spec.js
+++ b/tests/unit/aosGating.spec.js
@@ -1,5 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { aosDisabled, initAOS } from '../../src/utils/aosGating.js';
+import {
+  aosDisabled,
+  initAOS,
+  shouldForceShowAos,
+  stuckAosInView,
+  startAosFailsafe,
+  stopAosFailsafe,
+} from '../../src/utils/aosGating.js';
 
 vi.mock('aos', () => ({ default: { init: vi.fn() } }));
 import AOS from 'aos';
@@ -123,5 +130,67 @@ describe('initAOS — gate + init in one owner', () => {
       if (bodyDesc) Object.defineProperty(document, 'body', bodyDesc);
       else delete document.body;
     }
+  });
+});
+
+describe('AOS failsafe — content can never stay hidden on capable devices', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    document.body.classList.remove('aos-disabled');
+    stopAosFailsafe(); // clear any watch an initAOS test left running
+  });
+
+  afterEach(() => {
+    stopAosFailsafe();
+  });
+
+  const addStuck = (id, top, height = 100) => {
+    const el = document.createElement('div');
+    el.setAttribute('data-aos', 'fade-up');
+    el.id = id;
+    // jsdom does no layout, so getBoundingClientRect is all zeros — stub it
+    // to the element's declared top/height so viewport math is testable.
+    el.getBoundingClientRect = () => ({ top, bottom: top + height, left: 0, right: 0 });
+    document.body.appendChild(el);
+    return el;
+  };
+
+  it('force-shows a [data-aos] element that is in the viewport but lacks .aos-animate', () => {
+    const el = addStuck('in-view', 100);
+    expect(shouldForceShowAos(el, 800)).toBe(true);
+    startAosFailsafe();
+    expect(el.classList.contains('aos-animate')).toBe(true);
+  });
+
+  it('leaves below-the-fold elements hidden (AOS still owns the scroll reveal)', () => {
+    const el = addStuck('below-fold', 5000);
+    expect(shouldForceShowAos(el, 800)).toBe(false);
+    stuckAosInView(800);
+    expect(el.classList.contains('aos-animate')).toBe(false);
+  });
+
+  it('ignores elements AOS already revealed', () => {
+    const el = addStuck('already-animated', 100);
+    el.classList.add('aos-animate');
+    expect(shouldForceShowAos(el, 800)).toBe(false);
+  });
+
+  it('stuckAosInView returns exactly the in-view, unrevealed elements', () => {
+    const inView = addStuck('a', 100);
+    addStuck('b', 5000);
+    const done = addStuck('c', 200);
+    done.classList.add('aos-animate');
+    expect(stuckAosInView(800).map((el) => el.id)).toEqual(['a']);
+    expect(inView.classList.contains('aos-animate')).toBe(false);
+  });
+
+  it('the cleanup handle detaches the listeners (no force-show after cleanup)', () => {
+    const cleanup = startAosFailsafe();
+    cleanup();
+    // Added AFTER the watch started and stopped: the boot run never saw it,
+    // and a synthetic scroll must not reveal it either.
+    const el = addStuck('in-view', 100);
+    window.dispatchEvent(new Event('scroll'));
+    expect(el.classList.contains('aos-animate')).toBe(false);
   });
 });

--- a/tests/unit/carouselGeometry.spec.js
+++ b/tests/unit/carouselGeometry.spec.js
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CUBE_ANGLE,
+  slideStep,
+  flatTrackTransform,
+  cubeFaceTransform,
+  cubeTrackTransform,
+  cubeDragAngle,
+  dragSnap,
+} from '../../src/utils/carouselGeometry.js';
+
+describe('slideStep', () => {
+  it('is slide width plus the gap', () => {
+    expect(slideStep(300, 50)).toBe(350);
+    expect(slideStep(0, 0)).toBe(0);
+  });
+});
+
+describe('flatTrackTransform', () => {
+  it('translates left by activeIndex * step', () => {
+    expect(flatTrackTransform(0, 350)).toBe('translate3d(0px, 0, 0)');
+    expect(flatTrackTransform(2, 350)).toBe('translate3d(-700px, 0, 0)');
+  });
+
+  it('previews a drag offset (dragging left adds a positive offset back)', () => {
+    expect(flatTrackTransform(2, 350, 120)).toBe('translate3d(-580px, 0, 0)');
+    expect(flatTrackTransform(2, 350, -120)).toBe('translate3d(-820px, 0, 0)');
+  });
+});
+
+describe('cube transforms (match Swiper EffectCube orientation)', () => {
+  it('CUBE_ANGLE is 90° per face', () => {
+    expect(CUBE_ANGLE).toBe(90);
+  });
+
+  it('each face rotates by index * 90° and pushes out to the radius', () => {
+    expect(cubeFaceTransform(0, 160)).toBe('rotateY(0deg) translateZ(160px)');
+    expect(cubeFaceTransform(1, 160)).toBe('rotateY(90deg) translateZ(160px)');
+    expect(cubeFaceTransform(3, 160)).toBe('rotateY(270deg) translateZ(160px)');
+  });
+
+  it('the track rotates -90° per active face', () => {
+    expect(cubeTrackTransform(0)).toBe('rotateY(0deg)');
+    expect(cubeTrackTransform(1)).toBe('rotateY(-90deg)');
+    expect(cubeTrackTransform(4)).toBe('rotateY(-360deg)');
+  });
+
+  it('combines the active face with a drag angle', () => {
+    expect(cubeTrackTransform(2, 18)).toBe('rotateY(-198deg)');
+  });
+
+  it('a full face width of drag equals one 90° turn', () => {
+    expect(cubeDragAngle(160, 320)).toBe(45);
+    expect(cubeDragAngle(-320, 320)).toBe(-90);
+    expect(cubeDragAngle(50, 0)).toBe(0); // guard divide-by-zero
+  });
+});
+
+describe('dragSnap', () => {
+  it('dragging left past the threshold advances to next', () => {
+    expect(dragSnap(-200, 350, 0)).toBe(1);
+  });
+
+  it('dragging right past the threshold goes to previous', () => {
+    expect(dragSnap(200, 350, 0)).toBe(-1);
+  });
+
+  it('a short drag snaps back in place', () => {
+    expect(dragSnap(-60, 350, 0)).toBe(0);
+  });
+
+  it('a fast flick overrides a short drag', () => {
+    expect(dragSnap(-40, 350, -1.2)).toBe(1);
+    expect(dragSnap(40, 350, 1.2)).toBe(-1);
+  });
+
+  it('uses the custom threshold ratio', () => {
+    expect(dragSnap(-100, 350, 0, 0.25)).toBe(1); // 87.5 threshold
+    expect(dragSnap(-80, 350, 0, 0.25)).toBe(0);
+  });
+});

--- a/tests/unit/carouselGeometry.spec.js
+++ b/tests/unit/carouselGeometry.spec.js
@@ -45,8 +45,13 @@ describe('cube transforms (match Swiper EffectCube orientation)', () => {
     expect(cubeTrackTransform(4)).toBe('rotateY(-360deg)');
   });
 
-  it('combines the active face with a drag angle', () => {
-    expect(cubeTrackTransform(2, 18)).toBe('rotateY(-198deg)');
+  it('previews drag toward the NEXT face when dragging left (negative angle makes the rotation more negative — the direction dragSnap settles on)', () => {
+    expect(cubeTrackTransform(2, -18)).toBe('rotateY(-198deg)');
+    expect(cubeTrackTransform(4, -24)).toBe('rotateY(-384deg)');
+  });
+
+  it('previews drag toward the PREVIOUS face when dragging right', () => {
+    expect(cubeTrackTransform(2, 18)).toBe('rotateY(-162deg)');
   });
 
   it('a full face width of drag equals one 90° turn', () => {
@@ -72,6 +77,15 @@ describe('dragSnap', () => {
   it('a fast flick overrides a short drag', () => {
     expect(dragSnap(-40, 350, -1.2)).toBe(1);
     expect(dragSnap(40, 350, 1.2)).toBe(-1);
+  });
+
+  it('a fast flick does NOT advance on a stationary tap (micro-jitter < 10px)', () => {
+    // An 8px jitter 1ms after the last move reads 8px/ms — well over the
+    // flick threshold — but must not turn a face the user meant as a tap.
+    expect(dragSnap(-8, 350, -8)).toBe(0);
+    expect(dragSnap(8, 350, 8)).toBe(0);
+    // A genuine short flick still wins.
+    expect(dragSnap(-12, 350, -8)).toBe(1);
   });
 
   it('uses the custom threshold ratio', () => {

--- a/tests/unit/useAosFailsafe.spec.jsx
+++ b/tests/unit/useAosFailsafe.spec.jsx
@@ -48,17 +48,28 @@ function FailsafeProbe() {
 
 let harness;
 
+// The watch schedules force-show via rAF. Capture the callbacks into a queue
+// instead of running them synchronously — tests flush explicitly, and the
+// teardown test can prove an in-flight frame is cancelled on unmount.
+let rafQueue = [];
+const flushRaf = () => {
+  const q = rafQueue;
+  rafQueue = [];
+  q.forEach((cb) => cb && cb());
+};
+
 beforeEach(() => {
   setUrl('');
   stubNavigator();
   stubReducedMotion(false);
-  // The scroll/resize path schedules force-show via rAF; run it synchronously
-  // so scroll-driven reveals are deterministic in jsdom.
+  rafQueue = [];
   vi.stubGlobal('requestAnimationFrame', (cb) => {
-    cb();
-    return 1;
+    rafQueue.push(cb);
+    return rafQueue.length;
   });
-  vi.stubGlobal('cancelAnimationFrame', () => {});
+  vi.stubGlobal('cancelAnimationFrame', (id) => {
+    rafQueue[id - 1] = null; // a cancelled frame must not run on flush
+  });
   document.body.innerHTML = '';
   harness = createHarness();
 });
@@ -91,8 +102,10 @@ describe('useAosFailsafe — capable device', () => {
     // after boot; no scroll/resize may ever fire for them).
     const el = addStuck('late', 100);
     expect(el.classList.contains('aos-animate')).toBe(false);
-    // MutationObserver delivers asynchronously — let the microtask run.
-    await new Promise((r) => setTimeout(r, 0));
+    // MutationObserver delivers asynchronously — let the microtask run, then
+    // flush the rAF frame the observer scheduled.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    flushRaf();
     expect(el.classList.contains('aos-animate')).toBe(true);
   });
 
@@ -102,6 +115,7 @@ describe('useAosFailsafe — capable device', () => {
     expect(el.classList.contains('aos-animate')).toBe(false);
     el.getBoundingClientRect = () => ({ top: 100, bottom: 200, left: 0, right: 0 });
     window.dispatchEvent(new Event('scroll'));
+    flushRaf();
     expect(el.classList.contains('aos-animate')).toBe(true);
   });
 });
@@ -119,14 +133,19 @@ describe('useAosFailsafe — gated device', () => {
 });
 
 describe('useAosFailsafe — teardown', () => {
-  it('detaches the listeners AND the MutationObserver on unmount (no force-show after cleanup)', async () => {
+  it('cancels work queued while mounted AND stops catching new insertions after unmount', async () => {
     harness.render(<FailsafeProbe />);
-    harness.unmount();
-    // Added AFTER the watch stopped: neither a boot run, a scroll, nor the
-    // MutationObserver may reveal it.
-    const el = addStuck('in-view', 100);
+    // Queue a force-show frame while the watch is still alive: an in-view
+    // stuck element plus a scroll. The frame must be CANCELLED by cleanup.
+    const before = addStuck('queued-before-unmount', 100);
     window.dispatchEvent(new Event('scroll'));
-    await new Promise((r) => setTimeout(r, 0)); // drain observer + rAF queues
-    expect(el.classList.contains('aos-animate')).toBe(false);
+    expect(rafQueue.some(Boolean)).toBe(true); // work really was scheduled
+    harness.unmount();
+    // Added AFTER the watch stopped: the MutationObserver must be gone too.
+    const after = addStuck('inserted-after-unmount', 100);
+    await new Promise((resolve) => setTimeout(resolve, 0)); // drain observer
+    flushRaf(); // the cancelled frame must be a no-op
+    expect(before.classList.contains('aos-animate')).toBe(false);
+    expect(after.classList.contains('aos-animate')).toBe(false);
   });
 });

--- a/tests/unit/useAosFailsafe.spec.jsx
+++ b/tests/unit/useAosFailsafe.spec.jsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import useAosFailsafe from '../../src/hooks/useAosFailsafe.js';
+import { createHarness } from './harness.jsx';
+
+// useAosFailsafe owns the browser lifecycle of the AOS viewport failsafe; the
+// pure decisions (shouldForceShowAos / stuckAosInView) are covered in
+// aosGating.spec.js. Here we verify the hook wiring: it starts the watch on
+// capable devices (boot force-show of in-view stuck elements), skips gated
+// devices entirely (the body.aos-disabled CSS net covers them), and detaches
+// listeners on unmount.
+
+// aosDisabled reads detectProfile() (window.location.search, matchMedia,
+// navigator) at effect time — stub them the same way aosGating.spec does.
+function setUrl(search) {
+  window.history.replaceState({}, '', `/${search}`);
+}
+
+function stubNavigator({ connection = null, cores = 8, ram = 8 } = {}) {
+  const nav = { hardwareConcurrency: cores, deviceMemory: ram };
+  if (connection) nav.connection = connection;
+  vi.stubGlobal('navigator', nav);
+}
+
+function stubReducedMotion(reduce) {
+  vi.stubGlobal('matchMedia', (query) => ({
+    matches: reduce && query === '(prefers-reduced-motion: reduce)',
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }));
+}
+
+// jsdom does no layout, so getBoundingClientRect is all zeros — stub it to the
+// element's declared top/height so viewport math is testable.
+function addStuck(id, top, height = 100) {
+  const el = document.createElement('div');
+  el.setAttribute('data-aos', 'fade-up');
+  el.id = id;
+  el.getBoundingClientRect = () => ({ top, bottom: top + height, left: 0, right: 0 });
+  document.body.appendChild(el);
+  return el;
+}
+
+function FailsafeProbe() {
+  useAosFailsafe();
+  return <div className="failsafe-probe" />;
+}
+
+let harness;
+
+beforeEach(() => {
+  setUrl('');
+  stubNavigator();
+  stubReducedMotion(false);
+  // The scroll/resize path schedules force-show via rAF; run it synchronously
+  // so scroll-driven reveals are deterministic in jsdom.
+  vi.stubGlobal('requestAnimationFrame', (cb) => {
+    cb();
+    return 1;
+  });
+  vi.stubGlobal('cancelAnimationFrame', () => {});
+  document.body.innerHTML = '';
+  harness = createHarness();
+});
+
+afterEach(() => {
+  harness.unmount();
+  document.body.innerHTML = '';
+  vi.unstubAllGlobals();
+  setUrl('');
+});
+
+describe('useAosFailsafe — capable device', () => {
+  it('force-shows an in-view [data-aos] element AOS left hidden (boot run)', () => {
+    const el = addStuck('in-view', 100);
+    harness.render(<FailsafeProbe />);
+    expect(el.classList.contains('aos-animate')).toBe(true);
+  });
+
+  it('leaves below-the-fold elements hidden (AOS still owns the scroll reveal)', () => {
+    addStuck('below-fold', 5000);
+    harness.render(<FailsafeProbe />);
+    const el = document.getElementById('below-fold');
+    expect(el.classList.contains('aos-animate')).toBe(false);
+  });
+
+  it('a scroll reveals a stuck element that was added after boot', () => {
+    harness.render(<FailsafeProbe />);
+    const el = addStuck('late', 100);
+    expect(el.classList.contains('aos-animate')).toBe(false); // boot run already passed
+    window.dispatchEvent(new Event('scroll'));
+    expect(el.classList.contains('aos-animate')).toBe(true);
+  });
+});
+
+describe('useAosFailsafe — gated device', () => {
+  it('does not start the watch (body.aos-disabled CSS net covers reveals)', () => {
+    setUrl('?motion=off');
+    const el = addStuck('in-view', 100);
+    harness.render(<FailsafeProbe />);
+    expect(el.classList.contains('aos-animate')).toBe(false);
+    // And no listeners are attached: a scroll must not reveal it either.
+    window.dispatchEvent(new Event('scroll'));
+    expect(el.classList.contains('aos-animate')).toBe(false);
+  });
+});
+
+describe('useAosFailsafe — teardown', () => {
+  it('detaches the listeners on unmount (no force-show after cleanup)', () => {
+    harness.render(<FailsafeProbe />);
+    harness.unmount();
+    // Added AFTER the watch stopped: neither a boot run nor a scroll may
+    // reveal it.
+    const el = addStuck('in-view', 100);
+    window.dispatchEvent(new Event('scroll'));
+    expect(el.classList.contains('aos-animate')).toBe(false);
+  });
+});

--- a/tests/unit/useAosFailsafe.spec.jsx
+++ b/tests/unit/useAosFailsafe.spec.jsx
@@ -84,10 +84,23 @@ describe('useAosFailsafe — capable device', () => {
     expect(el.classList.contains('aos-animate')).toBe(false);
   });
 
-  it('a scroll reveals a stuck element that was added after boot', () => {
+  it('observes post-boot insertions — an in-view [data-aos] element is revealed without any viewport event', async () => {
     harness.render(<FailsafeProbe />);
+    // The boot run already passed, so this element is only caught by the
+    // MutationObserver (scroll-gated lazy sections mount their elements
+    // after boot; no scroll/resize may ever fire for them).
     const el = addStuck('late', 100);
-    expect(el.classList.contains('aos-animate')).toBe(false); // boot run already passed
+    expect(el.classList.contains('aos-animate')).toBe(false);
+    // MutationObserver delivers asynchronously — let the microtask run.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(el.classList.contains('aos-animate')).toBe(true);
+  });
+
+  it('a scroll reveals a stuck below-fold element once it enters the viewport', () => {
+    const el = addStuck('below-fold', 5000);
+    harness.render(<FailsafeProbe />);
+    expect(el.classList.contains('aos-animate')).toBe(false);
+    el.getBoundingClientRect = () => ({ top: 100, bottom: 200, left: 0, right: 0 });
     window.dispatchEvent(new Event('scroll'));
     expect(el.classList.contains('aos-animate')).toBe(true);
   });

--- a/tests/unit/useAosFailsafe.spec.jsx
+++ b/tests/unit/useAosFailsafe.spec.jsx
@@ -119,13 +119,14 @@ describe('useAosFailsafe — gated device', () => {
 });
 
 describe('useAosFailsafe — teardown', () => {
-  it('detaches the listeners on unmount (no force-show after cleanup)', () => {
+  it('detaches the listeners AND the MutationObserver on unmount (no force-show after cleanup)', async () => {
     harness.render(<FailsafeProbe />);
     harness.unmount();
-    // Added AFTER the watch stopped: neither a boot run nor a scroll may
-    // reveal it.
+    // Added AFTER the watch stopped: neither a boot run, a scroll, nor the
+    // MutationObserver may reveal it.
     const el = addStuck('in-view', 100);
     window.dispatchEvent(new Event('scroll'));
+    await new Promise((r) => setTimeout(r, 0)); // drain observer + rAF queues
     expect(el.classList.contains('aos-animate')).toBe(false);
   });
 });

--- a/tests/unit/useCarousel.spec.jsx
+++ b/tests/unit/useCarousel.spec.jsx
@@ -14,6 +14,18 @@ import { createHarness } from './harness.jsx';
 // handle the carousel-probe uses) — capturing a ref during render trips the
 // react-hooks lint rules.
 
+// jsdom may lack PointerEvent (it landed in later jsdom releases) — fall
+// back to a MouseEvent subclass carrying the pointer fields the hook reads.
+const PointerEventCtor =
+  globalThis.PointerEvent ||
+  class PointerEvent extends MouseEvent {
+    constructor(type, init = {}) {
+      super(type, init);
+      this.pointerId = init.pointerId ?? 0;
+      this.pointerType = init.pointerType ?? 'touch';
+    }
+  };
+
 let harness;
 
 function TrackProbe({
@@ -23,6 +35,7 @@ function TrackProbe({
   autoplayDelay = 0,
   initialIndex,
   faceWidth,
+  rerenderKey,
 }) {
   const elRef = useRef(null);
   const { trackRef } = useCarousel({
@@ -45,7 +58,7 @@ function TrackProbe({
             Object.defineProperty(node, 'clientWidth', { configurable: true, value: faceWidth });
           }
         }}
-        className="swiper-wrapper"
+        className={`swiper-wrapper ${rerenderKey}`}
       >
         {Array.from({ length: total * 3 }, (_, i) => (
           <div key={i} className="swiper-slide">
@@ -64,6 +77,7 @@ TrackProbe.propTypes = {
   autoplayDelay: PropTypes.number,
   initialIndex: PropTypes.number,
   faceWidth: PropTypes.number,
+  rerenderKey: PropTypes.number,
 };
 
 const slideEls = (root) => [...root.querySelectorAll('.swiper-slide')];
@@ -128,6 +142,18 @@ describe('useCarousel — instance contract', () => {
     expect(inst(harness).activeIndex).toBe(5); // unchanged — listener removed
   });
 
+  it('disableKeyboard removes the EXACT registered listener even after a re-render', () => {
+    // onKeyDown is re-created every render; disableKeyboard must drop the
+    // function that was actually added (a naive remove of the current closure
+    // would leave the original on window, driving a stale instance forever).
+    harness.render(<TrackProbe total={4} rerenderKey={1} />);
+    inst(harness).keyboard.enable();
+    harness.render(<TrackProbe total={4} rerenderKey={2} />); // new closure
+    inst(harness).keyboard.disable();
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', cancelable: true }));
+    expect(inst(harness).activeIndex).toBe(4); // stale listener must be gone
+  });
+
   it('autoplay.start advances on the delay; stop halts it', () => {
     vi.useFakeTimers();
     harness.render(<TrackProbe total={4} autoplayDelay={100} />);
@@ -138,6 +164,33 @@ describe('useCarousel — instance contract', () => {
     expect(inst(harness).activeIndex).toBe(6);
     inst(harness).autoplay.stop();
     vi.advanceTimersByTime(300);
+    expect(inst(harness).activeIndex).toBe(6);
+  });
+
+  it('pauses autoplay during a pointer drag and resumes on release', () => {
+    vi.useFakeTimers();
+    harness.render(<TrackProbe total={4} autoplayDelay={100} />);
+    const root = harness.container.querySelector('.probe-root');
+    const track = root.querySelector('.swiper-wrapper');
+    inst(harness).autoplay.start();
+    const pointer = (type, x) =>
+      new PointerEventCtor(type, {
+        pointerId: 1,
+        pointerType: 'touch',
+        clientX: x,
+        bubbles: true,
+        cancelable: true,
+      });
+    track.dispatchEvent(pointer('pointerdown', 400));
+    // While the finger is down, the interval must NOT fire a goTo() — it
+    // would move the track under the user and corrupt the release snap.
+    vi.advanceTimersByTime(300);
+    expect(inst(harness).activeIndex).toBe(4);
+    track.dispatchEvent(pointer('pointermove', 350));
+    track.dispatchEvent(pointer('pointerup', 350));
+    expect(inst(harness).activeIndex).toBe(5); // release snap (left drag)
+    // Autoplay resumed: the next tick advances again.
+    vi.advanceTimersByTime(100);
     expect(inst(harness).activeIndex).toBe(6);
   });
 });
@@ -178,18 +231,6 @@ describe('useCarousel — cube mode', () => {
 });
 
 describe('useCarousel — pointer drag', () => {
-  // jsdom may lack PointerEvent (it landed in later jsdom releases) — fall
-  // back to a MouseEvent subclass carrying the pointer fields the hook reads.
-  const PointerEventCtor =
-    globalThis.PointerEvent ||
-    class PointerEvent extends MouseEvent {
-      constructor(type, init = {}) {
-        super(type, init);
-        this.pointerId = init.pointerId ?? 0;
-        this.pointerType = init.pointerType ?? 'touch';
-      }
-    };
-
   // Dispatch pointerdown + pointermove, and hand back the move (for preview
   // assertions) plus a finish() that dispatches pointerup.
   const dragStart = (root, fromX, toX) => {
@@ -234,6 +275,26 @@ describe('useCarousel — pointer drag', () => {
     expect(move.defaultPrevented).toBe(true);
     finish();
     expect(inst(harness).activeIndex).toBe(5);
+  });
+});
+
+describe('useCarousel — cube face gating across the 3-copy wrap', () => {
+  it('marks exactly active/next/prev on every raw position (the copies share 4 faces; classes decide which child is visible)', () => {
+    // TeamCarousel renders 3 copies of 11 slides; cubeFaceTransform(i) puts
+    // children i, i±4, ... on the SAME face. The CSS shows only the child
+    // carrying swiper-slide-active/next/prev — walk the whole wrap and assert
+    // exactly one child carries each class, at the correct raw position, so
+    // the visible member always matches the active index.
+    harness.render(<TrackProbe total={4} mode="cube" faceWidth={300} />);
+    const root = harness.container.querySelector('.probe-root');
+    const els = slideEls(root);
+    for (let raw = 0; raw < 12; raw++) {
+      inst(harness).slideTo(raw, 0);
+      const withClass = (name) => els.filter((el) => el.classList.contains(name));
+      expect(withClass('swiper-slide-active')).toEqual([els[raw]]);
+      expect(withClass('swiper-slide-next')).toEqual(raw + 1 < els.length ? [els[raw + 1]] : []);
+      expect(withClass('swiper-slide-prev')).toEqual(raw - 1 >= 0 ? [els[raw - 1]] : []);
+    }
   });
 });
 

--- a/tests/unit/useCarousel.spec.jsx
+++ b/tests/unit/useCarousel.spec.jsx
@@ -16,7 +16,14 @@ import { createHarness } from './harness.jsx';
 
 let harness;
 
-function TrackProbe({ total = 4, mode = 'flat', onActiveChange, autoplayDelay = 0, initialIndex }) {
+function TrackProbe({
+  total = 4,
+  mode = 'flat',
+  onActiveChange,
+  autoplayDelay = 0,
+  initialIndex,
+  faceWidth,
+}) {
   const elRef = useRef(null);
   const { trackRef } = useCarousel({
     elRef,
@@ -28,7 +35,18 @@ function TrackProbe({ total = 4, mode = 'flat', onActiveChange, autoplayDelay = 
   });
   return (
     <div ref={elRef} className="probe-root">
-      <div ref={trackRef} className="swiper-wrapper">
+      <div
+        ref={(node) => {
+          // jsdom does no layout (clientWidth is 0), so a cube drag's face
+          // width must be injected before the hook's measure() runs (refs
+          // attach before layout effects). Only the cube test needs it.
+          trackRef.current = node;
+          if (node && faceWidth) {
+            Object.defineProperty(node, 'clientWidth', { configurable: true, value: faceWidth });
+          }
+        }}
+        className="swiper-wrapper"
+      >
         {Array.from({ length: total * 3 }, (_, i) => (
           <div key={i} className="swiper-slide">
             slide {i % total}
@@ -45,6 +63,7 @@ TrackProbe.propTypes = {
   onActiveChange: PropTypes.func,
   autoplayDelay: PropTypes.number,
   initialIndex: PropTypes.number,
+  faceWidth: PropTypes.number,
 };
 
 const slideEls = (root) => [...root.querySelectorAll('.swiper-slide')];
@@ -58,6 +77,10 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // Always restore real timers here — if an autoplay/wrap test's fake timers
+  // are still active when an assertion fails mid-test, every later test in
+  // this file would inherit them.
+  vi.useRealTimers();
   vi.unstubAllGlobals();
   harness.unmount();
 });
@@ -116,7 +139,6 @@ describe('useCarousel — instance contract', () => {
     inst(harness).autoplay.stop();
     vi.advanceTimersByTime(300);
     expect(inst(harness).activeIndex).toBe(6);
-    vi.useRealTimers();
   });
 });
 
@@ -155,6 +177,66 @@ describe('useCarousel — cube mode', () => {
   });
 });
 
+describe('useCarousel — pointer drag', () => {
+  // jsdom may lack PointerEvent (it landed in later jsdom releases) — fall
+  // back to a MouseEvent subclass carrying the pointer fields the hook reads.
+  const PointerEventCtor =
+    globalThis.PointerEvent ||
+    class PointerEvent extends MouseEvent {
+      constructor(type, init = {}) {
+        super(type, init);
+        this.pointerId = init.pointerId ?? 0;
+        this.pointerType = init.pointerType ?? 'touch';
+      }
+    };
+
+  // Dispatch pointerdown + pointermove, and hand back the move (for preview
+  // assertions) plus a finish() that dispatches pointerup.
+  const dragStart = (root, fromX, toX) => {
+    const track = root.querySelector('.swiper-wrapper');
+    const pointer = (type, x) =>
+      new PointerEventCtor(type, {
+        pointerId: 1,
+        pointerType: 'touch',
+        clientX: x,
+        bubbles: true,
+        cancelable: true,
+      });
+    track.dispatchEvent(pointer('pointerdown', fromX));
+    const move = pointer('pointermove', toX);
+    track.dispatchEvent(move);
+    return { track, move, finish: () => track.dispatchEvent(pointer('pointerup', toX)) };
+  };
+
+  it('flat: drag previews the offset during the move, prevents the browser default, and settles on the next index', () => {
+    harness.render(<TrackProbe total={4} mode="flat" />);
+    const root = harness.container.querySelector('.probe-root');
+    const { track, move, finish } = dragStart(root, 400, 320); // 80px left
+    // During the drag the track previews the gesture (content follows the
+    // finger) and owns it (preventDefault — ADR-0007 gesture ownership).
+    expect(track.style.transform).toContain('translate3d(-80px, 0, 0)');
+    expect(move.defaultPrevented).toBe(true);
+    finish();
+    // Release: a left drag settles on the next slide (raw 4 → 5).
+    expect(inst(harness).activeIndex).toBe(5);
+  });
+
+  it('cube: drag left previews toward the NEXT face and settles there (sign regression)', () => {
+    harness.render(<TrackProbe total={4} mode="cube" faceWidth={300} />);
+    const root = harness.container.querySelector('.probe-root');
+    const { track, move, finish } = dragStart(root, 400, 320); // 80px left
+    // faceWidth 300 → cubeDragAngle(-80, 300) = -24°. Base -4×90 = -360°, so
+    // the preview must read rotateY(-384deg) — MORE negative, toward the next
+    // face, the same direction dragSnap settles on. (The old sign negated the
+    // drag term and previewed the previous face, making the cube jump on
+    // release.)
+    expect(track.style.transform).toContain('rotateY(-384deg)');
+    expect(move.defaultPrevented).toBe(true);
+    finish();
+    expect(inst(harness).activeIndex).toBe(5);
+  });
+});
+
 describe('useCarousel — seamless 3-copy wrap', () => {
   it('jumps back one copy when advancing past the last copy', () => {
     vi.useFakeTimers();
@@ -172,7 +254,6 @@ describe('useCarousel — seamless 3-copy wrap', () => {
       .dispatchEvent(new Event('transitionend', { bubbles: true }));
     // wrapTarget(9, 4) = 9 - 4 = 5 — same normalized slide, no visible jump
     expect(inst(harness).activeIndex).toBe(5);
-    vi.useRealTimers();
   });
 
   it('jumps forward one copy when going before the first copy', () => {

--- a/tests/unit/useCarousel.spec.jsx
+++ b/tests/unit/useCarousel.spec.jsx
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useRef } from 'react';
+import PropTypes from 'prop-types';
+import useCarousel from '../../src/hooks/useCarousel.js';
+import { createHarness } from './harness.jsx';
+
+// useCarousel drives a real DOM track (transforms, class toggling, pointer
+// listeners). jsdom gives us the DOM; the harness mounts the hook. We assert
+// the swiper-shaped instance contract the seams rely on — slideTo/slidePrev/
+// slideNext, keyboard.enable/disable, autoplay.start/stop — plus the
+// .swiper-slide-active class the E2E suite reads, and the 3-copy wrap.
+//
+// The instance is read from the root's __carousel__ debug handle (the same
+// handle the carousel-probe uses) — capturing a ref during render trips the
+// react-hooks lint rules.
+
+let harness;
+
+function TrackProbe({ total = 4, mode = 'flat', onActiveChange, autoplayDelay = 0, initialIndex }) {
+  const elRef = useRef(null);
+  const { trackRef } = useCarousel({
+    elRef,
+    total,
+    mode,
+    autoplayDelay,
+    initialIndex,
+    onActiveChange,
+  });
+  return (
+    <div ref={elRef} className="probe-root">
+      <div ref={trackRef} className="swiper-wrapper">
+        {Array.from({ length: total * 3 }, (_, i) => (
+          <div key={i} className="swiper-slide">
+            slide {i % total}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+TrackProbe.propTypes = {
+  total: PropTypes.number,
+  mode: PropTypes.oneOf(['flat', 'cube']),
+  onActiveChange: PropTypes.func,
+  autoplayDelay: PropTypes.number,
+  initialIndex: PropTypes.number,
+};
+
+const slideEls = (root) => [...root.querySelectorAll('.swiper-slide')];
+const activeEl = (root) =>
+  slideEls(root).find((el) => el.classList.contains('swiper-slide-active'));
+
+const inst = (harness) => harness.container.querySelector('.probe-root').__carousel__;
+
+beforeEach(() => {
+  harness = createHarness();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  harness.unmount();
+});
+
+describe('useCarousel — instance contract', () => {
+  it('starts in the middle copy (initialIndex = total) so the wrap never trips on mount', () => {
+    harness.render(<TrackProbe total={4} />);
+    expect(inst(harness).activeIndex).toBe(4);
+    expect(activeEl(harness.container)).toBe(slideEls(harness.container)[4]);
+  });
+
+  it('slideNext / slidePrev move by one and report the raw index', () => {
+    harness.render(<TrackProbe total={4} />);
+    inst(harness).slideNext();
+    expect(inst(harness).activeIndex).toBe(5);
+    expect(activeEl(harness.container)).toBe(slideEls(harness.container)[5]);
+    inst(harness).slidePrev();
+    expect(inst(harness).activeIndex).toBe(4);
+  });
+
+  it('slideTo jumps to an explicit raw index', () => {
+    harness.render(<TrackProbe total={4} />);
+    inst(harness).slideTo(7, 0);
+    expect(inst(harness).activeIndex).toBe(7);
+    expect(activeEl(harness.container)).toBe(slideEls(harness.container)[7]);
+  });
+
+  it('fires onActiveChange with the NORMALIZED index on every settle', () => {
+    const seen = [];
+    harness.render(<TrackProbe total={4} onActiveChange={(i) => seen.push(i)} />);
+    expect(seen).toEqual([0]); // mount settle at middle copy → normalized 0
+
+    inst(harness).slideNext();
+    inst(harness).slideNext();
+    expect(seen).toEqual([0, 1, 2]);
+  });
+
+  it('keyboard.enable listens for arrows and advances; disable stops it', () => {
+    harness.render(<TrackProbe total={4} />);
+    inst(harness).keyboard.enable();
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', cancelable: true }));
+    expect(inst(harness).activeIndex).toBe(5);
+    inst(harness).keyboard.disable();
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', cancelable: true }));
+    expect(inst(harness).activeIndex).toBe(5); // unchanged — listener removed
+  });
+
+  it('autoplay.start advances on the delay; stop halts it', () => {
+    vi.useFakeTimers();
+    harness.render(<TrackProbe total={4} autoplayDelay={100} />);
+    inst(harness).autoplay.start();
+    vi.advanceTimersByTime(100);
+    expect(inst(harness).activeIndex).toBe(5);
+    vi.advanceTimersByTime(100);
+    expect(inst(harness).activeIndex).toBe(6);
+    inst(harness).autoplay.stop();
+    vi.advanceTimersByTime(300);
+    expect(inst(harness).activeIndex).toBe(6);
+    vi.useRealTimers();
+  });
+});
+
+describe('useCarousel — cube mode', () => {
+  it('sets the 3D scaffolding (perspective, preserve-3d, absolute faces)', () => {
+    harness.render(<TrackProbe total={4} mode="cube" />);
+    const root = harness.container.querySelector('.probe-root');
+    expect(root.style.perspective).toBe('1200px');
+    const track = root.querySelector('.swiper-wrapper');
+    expect(track.style.transformStyle).toBe('preserve-3d');
+    const face = track.querySelector('.swiper-slide');
+    expect(face.style.position).toBe('absolute');
+    expect(face.style.backfaceVisibility).toBe('hidden');
+  });
+
+  it('gates the face-hiding CSS behind data-carousel-ready (failsafe: no hidden content if the hook dies)', () => {
+    // The cube's visibility:hidden rule only applies once the hook has
+    // successfully applied transforms + active classes — so a chunk/JS
+    // failure leaves the faces visible (stacked) instead of blank.
+    harness.render(<TrackProbe total={4} mode="cube" />);
+    const root = harness.container.querySelector('.probe-root');
+    expect(root.getAttribute('data-carousel-mode')).toBe('cube');
+    expect(root.hasAttribute('data-carousel-ready')).toBe(true);
+    // And the active face is the one that would be visible (middle copy 4).
+    expect(root.querySelector('.swiper-slide-active')).toBe(slideEls(root)[4]);
+  });
+
+  it('rotates the track by -90° per active face', () => {
+    harness.render(<TrackProbe total={4} mode="cube" />);
+    const root = harness.container.querySelector('.probe-root');
+    const track = root.querySelector('.swiper-wrapper');
+    expect(track.style.transform).toContain('rotateY(-360deg)'); // middle copy 4
+
+    inst(harness).slideNext();
+    expect(track.style.transform).toContain('rotateY(-450deg)');
+  });
+});
+
+describe('useCarousel — seamless 3-copy wrap', () => {
+  it('jumps back one copy when advancing past the last copy', () => {
+    vi.useFakeTimers();
+    harness.render(<TrackProbe total={4} autoplayDelay={100} />);
+    const root = harness.container.querySelector('.probe-root');
+    inst(harness).autoplay.start();
+    // from raw 4 → 5 → 6 → 7 (still middle copy) → 8 (last copy start)
+    vi.advanceTimersByTime(100 * 4);
+    expect(inst(harness).activeIndex).toBe(8);
+    // next tick crosses into the 3rd copy; the transitionend handler wraps back
+    vi.advanceTimersByTime(100);
+    expect(inst(harness).activeIndex).toBe(9);
+    root
+      .querySelector('.swiper-wrapper')
+      .dispatchEvent(new Event('transitionend', { bubbles: true }));
+    // wrapTarget(9, 4) = 9 - 4 = 5 — same normalized slide, no visible jump
+    expect(inst(harness).activeIndex).toBe(5);
+    vi.useRealTimers();
+  });
+
+  it('jumps forward one copy when going before the first copy', () => {
+    harness.render(<TrackProbe total={4} initialIndex={4} />);
+    const root = harness.container.querySelector('.probe-root');
+    inst(harness).slideTo(0, 0);
+    expect(inst(harness).activeIndex).toBe(0);
+    root
+      .querySelector('.swiper-wrapper')
+      .dispatchEvent(new Event('transitionend', { bubbles: true }));
+    // wrapTarget(0, 4) = 0 + 4 = 4 — back into the middle copy
+    expect(inst(harness).activeIndex).toBe(4);
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -178,9 +178,6 @@ export default defineConfig({
             ) {
               return 'react-vendor';
             }
-            if (id.includes('/node_modules/swiper/')) {
-              return 'swiper-vendor';
-            }
             // NOTE: no react-icons grouping on purpose. Every react-icons
             // consumer (ContactUs, Footer, Featuring) is lazy, so forcing an
             // eager 'icons-vendor' chunk hoisted its shared React core into


### PR DESCRIPTION
## What

Two changes, split into two commits:

### 1. `feat(perf)` — Swiper → hand-rolled cube + flat carousels (`209ade3`)

Swiper was the last big vendor chunk (\~104 KB raw / 30.4 KB gz). Replaced with a hand-rolled engine preserving every behavior the site relied on:

- **`src/hooks/useCarousel.js`** — swiper-shaped instance (`el`, `slides`, `activeIndex`, `slideTo/Prev/Next`, `keyboard.enable/disable`, `autoplay.start/stop/resume`) so all consuming seams work unchanged: `keyboardLock` arrow arbitration, `useAutoplayOnScreen` gating, the E2E suite.
- **`src/utils/carouselGeometry.js`** — pure math replicating EffectCube (rotateY 90° per face, track `-activeIndex*90°`), flat offsets, drag-snap with flick detection.
- **Execom TeamCarousel** — 3D cube preserved (desktop + mobile), flat fallback on low-power with responsive 2/3/4-per-view + arrows, touch drag (`touch-action: none` + non-passive `preventDefault`), keyboard arbitration, dots, on-screen autoplay.
- **Featuring** — flat slider, arrows, dots, autoplay, slide aria-labels.
- **Failsafe** — cube face-hiding CSS gated behind `data-carousel-ready` (set only after first transforms + active classes apply), so a failed chunk leaves faces visible instead of a blank section.

Removed the swiper dep, `swiper-vendor` manual chunk, knip/dependabot entries; renamed `tests/swiper-lazy.spec.js` → `tests/carousel-lazy.spec.js` (now checks carousel chunk deferral). `.swiper-slide`/`.swiper-wrapper` stay as stable DOM hooks for E2E + CSS.

### 2. `fix(a11y)` — AOS viewport failsafe (`3c00f72`)

On capable devices, only AOS's scroll observer reveals `[data-aos]` content — if its JS breaks or misses an element, visible content stays `opacity: 0` forever (the existing net only covered gated devices + reduced motion). Adds a rAF-throttled passive scroll/resize watch that force-adds `.aos-animate` to in-view stuck elements: pure `shouldForceShowAos` / `stuckAosInView` + `startAosFailsafe` wiring (ADR-0009), enabled only for capable devices, torn down by `stopAosFailsafe`.

## Verification

| Gate | Result |
|---|---|
| Unit tests | **513 passed** (23 new: carousel geometry + hook contract/wrap/cube, 6 AOS failsafe) |
| E2E full suite | **79 passed, 0 failed** (13 expected skips) — cube drag, touch-action + preventDefault, dot/keyboard nav, boot deferral, axe scans |
| `pnpm verify` | exit 0 (lint, format, check-specs, check-assets, check-sw, build, diff) |
| knip | 0 unused deps |

**Bundle:** `swiper-vendor` gone; Featuring chunk 6.3 KB raw, Execom 10.7 KB raw.