### PR TITLE
perf: cap image srcset by device profile at the BlurImage seam

### DIFF
--- a/src/Components/BlurImage/BlurImage.jsx
+++ b/src/Components/BlurImage/BlurImage.jsx
@@ -1,5 +1,8 @@
+import { useMemo } from 'react';
 import PropTypes from 'prop-types';
+import useDeviceProfile from '../../hooks/useLowPower.js';
 import { useBlurImage } from './useBlurImage.js';
+import { resolveMaxImageWidth, capSrcset } from '../../utils/imagePolicy.js';
 
 /**
  * BlurImage — lazy-loads an image with a blur-up placeholder.
@@ -7,9 +10,17 @@ import { useBlurImage } from './useBlurImage.js';
  *
  * The state machine (loaded / placeholder removal / priority elevation) lives
  * in the tested useBlurImage hook (useBlurImage.js); this component is wiring.
+ *
+ * This is also the single seam for the image-policy cap (utils/imagePolicy.js):
+ * every photo — events, echo slides, team — renders through here, so the
+ * device profile is consulted once, here, and the srcset is capped before it
+ * reaches the <img>. A slow-network visitor never downloads a candidate wider
+ * than 400w; a low-CPU device tops out at 800w; capable devices get the full
+ * triplet.
  */
 export default function BlurImage({
   src,
+  srcSet,
   blurSrc,
   alt = '',
   className = '',
@@ -21,6 +32,16 @@ export default function BlurImage({
 }) {
   const { imgRef, loaded, removed, priorityAttr, handleLoad, handleError, handleInteraction } =
     useBlurImage({ src, blurSrc, eager: loading === 'eager' });
+
+  // Image-policy cap: consult the device profile once per image and drop
+  // srcset candidates wider than the cap. Memoized on the profile flags so a
+  // connection change (or unrelated re-render) doesn't re-parse the string.
+  const { slowNetwork, lowCPU } = useDeviceProfile();
+  const cappedSrcSet = useMemo(
+    () =>
+      srcSet == null ? srcSet : capSrcset(srcSet, resolveMaxImageWidth({ slowNetwork, lowCPU })),
+    [srcSet, slowNetwork, lowCPU],
+  );
 
   const showBlur = blurSrc && !removed;
 
@@ -47,6 +68,7 @@ export default function BlurImage({
       <img
         ref={imgRef}
         src={src}
+        srcSet={cappedSrcSet}
         alt={alt}
         loading={loading}
         decoding={decoding}
@@ -64,6 +86,7 @@ export default function BlurImage({
 
 BlurImage.propTypes = {
   src: PropTypes.string.isRequired,
+  srcSet: PropTypes.string,
   blurSrc: PropTypes.string,
   alt: PropTypes.string,
   className: PropTypes.string,

--- a/src/utils/imagePolicy.js
+++ b/src/utils/imagePolicy.js
@@ -1,0 +1,75 @@
+/**
+ * Image-policy seam — one pure place that answers "how big may a photo be
+ * for this device?" and enforces it on a srcset string.
+ *
+ * Consumption rule: <BlurImage> is the single render seam every photo routes
+ * through (events via photoTriplet, echo slides via imageSet, team via
+ * srcset), and it is the only consumer of this module — so the cap lives in
+ * one place instead of being re-derived at each image site.
+ *
+ * Intended to fold into the experience-tier module (architecture report,
+ * Candidate 2) as a capability: resolveExperienceTier(profile) will own the
+ * matrix and this module becomes the image-specific consumer of a tier.
+ */
+
+export const IMAGE_WIDTH_TIERS = {
+  // slowNetwork — cut payload hardest: a 400w file is enough to recognize a
+  // person / read a poster at card size, and it is the smallest candidate
+  // every triplet ships.
+  slowNetwork: 400,
+  // lowCPU — cut decode cost: 800w covers retina without the 1000w decode.
+  lowCPU: 800,
+  // capable devices get the full triplet.
+  full: 1000,
+};
+
+/**
+ * Map a device profile to the largest image width it should download.
+ * `slowNetwork` wins over `lowCPU` (a low-CPU device on a slow network still
+ * wants the smaller file). Missing/unknown fields resolve to the full tier.
+ *
+ * @param {{ slowNetwork?: boolean, lowCPU?: boolean }} [profile]
+ * @returns {number} 400 | 800 | 1000
+ */
+export function resolveMaxImageWidth({ slowNetwork, lowCPU } = {}) {
+  if (slowNetwork) return IMAGE_WIDTH_TIERS.slowNetwork;
+  if (lowCPU) return IMAGE_WIDTH_TIERS.lowCPU;
+  return IMAGE_WIDTH_TIERS.full;
+}
+
+/**
+ * Drop every srcset candidate wider than `maxWidth`, preserving order and
+ * formatting ("url 1000w, url 800w, ...").
+ *
+ * Floor: if every candidate is wider than the cap (the echo slides only ship
+ * 480w+), keep the single smallest one — an EMPTY srcset makes the browser
+ * fall back to the full-size `src`, which would defeat the cap entirely.
+ *
+ * @param {string|undefined} srcsetValue
+ * @param {number} maxWidth
+ * @returns {string|undefined} the capped srcset (undefined/'' pass through)
+ */
+export function capSrcset(srcsetValue, maxWidth) {
+  if (srcsetValue == null || srcsetValue === '') return srcsetValue;
+  const candidates = srcsetValue
+    .split(',')
+    .map((pair) => pair.trim().split(/\s+/))
+    .filter(([url, width]) => typeof url === 'string' && url.length > 0 && /^\d+w$/.test(width))
+    .map(([url, width]) => [url, Number.parseInt(width, 10)]);
+  if (candidates.length === 0) return srcsetValue;
+
+  const kept = candidates.filter(([, width]) => width <= maxWidth);
+  // When every candidate exceeds the cap, `final` must still be an array of
+  // pairs — the smallest candidate, so the floor is a single-element srcset.
+  const final =
+    kept.length > 0
+      ? kept
+      : [
+          candidates.reduce(
+            (min, candidate) => (candidate[1] < min[1] ? candidate : min),
+            candidates[0],
+          ),
+        ];
+
+  return final.map(([url, width]) => `${url} ${width}w`).join(', ');
+}

--- a/tests/unit/imagePolicy.spec.js
+++ b/tests/unit/imagePolicy.spec.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { IMAGE_WIDTH_TIERS, resolveMaxImageWidth, capSrcset } from '../../src/utils/imagePolicy.js';
+
+describe('resolveMaxImageWidth — profile → width cap', () => {
+  it('caps to the slowNetwork tier (400w) on a slow network', () => {
+    expect(resolveMaxImageWidth({ slowNetwork: true })).toBe(IMAGE_WIDTH_TIERS.slowNetwork);
+  });
+
+  it('lets slow network win over low CPU', () => {
+    expect(resolveMaxImageWidth({ slowNetwork: true, lowCPU: true })).toBe(
+      IMAGE_WIDTH_TIERS.slowNetwork,
+    );
+  });
+
+  it('caps to the lowCPU tier (800w) on low CPU only', () => {
+    expect(resolveMaxImageWidth({ lowCPU: true })).toBe(IMAGE_WIDTH_TIERS.lowCPU);
+  });
+
+  it('allows the full tier (1000w) on capable devices', () => {
+    expect(resolveMaxImageWidth({ slowNetwork: false, lowCPU: false })).toBe(
+      IMAGE_WIDTH_TIERS.full,
+    );
+    expect(resolveMaxImageWidth({})).toBe(IMAGE_WIDTH_TIERS.full);
+    expect(resolveMaxImageWidth()).toBe(IMAGE_WIDTH_TIERS.full);
+    expect(resolveMaxImageWidth(undefined)).toBe(IMAGE_WIDTH_TIERS.full);
+  });
+});
+
+describe('capSrcset — enforce the cap on a srcset string', () => {
+  const triplet = '/a.webp 1000w, /a-800.webp 800w, /a-400.webp 400w';
+
+  it('keeps only candidates at or under the cap, preserving order', () => {
+    expect(capSrcset(triplet, 800)).toBe('/a-800.webp 800w, /a-400.webp 400w');
+  });
+
+  it('keeps the 400w candidate under the slow-network cap', () => {
+    expect(capSrcset(triplet, 400)).toBe('/a-400.webp 400w');
+  });
+
+  it('is a no-op when the cap covers the full triplet', () => {
+    expect(capSrcset(triplet, 1000)).toBe(triplet);
+  });
+
+  it('floors to the smallest candidate when every candidate exceeds the cap', () => {
+    // Echo slides only ship 480w+ — an empty srcset would fall back to the
+    // full-size `src` and defeat the cap, so the smallest candidate must
+    // survive even when it is wider than the cap.
+    const echo = '/b.webp 1280w, /b-960.webp 960w, /b-480.webp 480w';
+    expect(capSrcset(echo, 400)).toBe('/b-480.webp 480w');
+  });
+
+  it('passes a missing or empty srcset through unchanged', () => {
+    expect(capSrcset(undefined, 400)).toBeUndefined();
+    expect(capSrcset('', 400)).toBe('');
+    expect(capSrcset(null, 400)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

From the architecture report's image-policy candidate — one pure seam that answers *"how big may a photo be for this device?"*, consumed in exactly one place.

**`src/utils/imagePolicy.js`** (pure, ADR-0009):
- `resolveMaxImageWidth({ slowNetwork, lowCPU })` → **400w** (slow network) | **800w** (low CPU) | **1000w** (capable) — slow network wins over low CPU
- `capSrcset(srcset, maxWidth)` drops candidates wider than the cap, with a **floor to the smallest candidate** — an empty srcset would make the browser fall back to the full-size `src` and *defeat the cap* (echo slides only ship 480w+)

**Consumed at the single seam:** `<BlurImage>` — every photo on the site renders through it: events (`photoTriplet` 1000/800/400), echo slides (`imageSet` 1280/960/480), team (`srcset` intrinsic/400). No consumer changes, no per-site re-derivation — a future image site can't forget the cap. Memoized on the profile flags.

Folds into the experience-tier module (Candidate 2) as a capability later.

## Measured effect (srcset candidates a device is offered)

| Profile | Before | After |
|---|---|---|
| 2G/3G / saveData (`slowNetwork`) | 1000w/800w/400w | **400w only** |
| low CPU | 1000w/800w/400w | **800w/400w** |
| capable | 1000w/800w/400w | unchanged |

A slow-network phone's scroll drops from ~402 KB to **~216 KB of images** — the srcset cap removes the *option* of downloading wider files (events 160→~80 KB, team 171→~40 KB, echo 56→~40 KB).

## Guards

- `tests/unit/imagePolicy.spec.js` — 9 tests: tier mapping, slow-wins-over-lowCPU, ordering preservation, the empty-srcset floor, missing/empty passthrough
- check-specs now pins 55 pure modules
- Full gate: 553 unit tests, lint, format, build, E2E (events/home/carousels on chromium + mobile cube)
