### PR TITLE
fix(perf): gate Vercel analytics mounting on the platform serving its scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ Read this before touching anything.
   `ariaActivation.js`, `aosGating.js` (gate + `initAOS`), `breakpoints.js` (viewports 500/767/768/1024),
   `carouselWrap.js` (shared wrap math), `scrollLock.js` (ref-counted body lock), `navigationCoordinator.js` (unified scroll/overlay/lock coordinator),
   `overlayLifecycle.js` (pure focus/trap/escape helpers), `routePrefetchLogic.js` (pure route loaders),
+  `analyticsProbe.js` (pure Vercel-script gate behind DeferredAnalytics),
   `DeferredAnalytics.jsx`, `lazyWithRetry.js`, `sessionCookie.js`, `scrollToSectionLogic.js`, `bootSplashLogic.js`.
 - `src/hooks/` — `useLowPower.js` (`useDeviceProfile` driving all perf degradation),
   `useViewportWidth.js` (reactive width over `breakpoints.js`),

--- a/src/utils/DeferredAnalytics.jsx
+++ b/src/utils/DeferredAnalytics.jsx
@@ -1,4 +1,10 @@
 import { useEffect, useState } from 'react';
+import {
+  VERCEL_INSIGHTS_ROUTE,
+  VERCEL_ANALYTICS_ROUTE,
+  isVercelScriptResponse,
+  mountAnalyticsIfServed,
+} from './analyticsProbe.js';
 
 /**
  * Analytics must never compete with the real page for network or CPU on first
@@ -7,12 +13,17 @@ import { useEffect, useState } from 'react';
  * when the safety timer fires, or once the browser is idle — whichever comes
  * first — so on 2G/3G the FOCES content wins the critical path.
  *
+ * Each integration mounts only when Vercel actually serves its /_vercel/
+ * script route (decisions live in the pure module analyticsProbe.js): off
+ * Vercel the SPA fallback would answer with index.html and the injected
+ * <script> would throw a parse error ("Unexpected token '<'").
+ *
  * Only the Vercel vendor module code (speed-insights/react and
  * analytics/react) is code-split behind the dynamic imports below — React
  * itself is statically imported above and is already part of the app
- * bundle. Each integration loads independently (Promise.allSettled): a
- * failure in one never blocks the other from mounting, and a failed vendor
- * chunk is best-effort — never an app error.
+ * bundle. Each integration loads independently; a failure in one never
+ * blocks the other from mounting, and a failed vendor chunk is
+ * best-effort — never an app error.
  */
 export default function DeferredAnalytics() {
   const [ready, setReady] = useState(false);
@@ -51,49 +62,38 @@ export default function DeferredAnalytics() {
   }, []);
 
   useEffect(() => {
-    if (!ready || (Insights && Analytics)) return;
+    if (!ready) return;
     let cancelled = false;
 
-    // Only Vercel serves the /_vercel/ analytics script routes. On any other
-    // static host the SPA fallback answers with index.html, and the injected
-    // <script> then throws a parse error ("Unexpected token '<'"). Probe each
-    // route and only boot the integration whose script the platform actually
-    // serves — best-effort per integration, never an app error.
-    const probe = (url) =>
-      typeof fetch === 'function'
-        ? fetch(url, { method: 'HEAD' })
-            .then((r) => (r.headers.get('content-type') || '').includes('javascript'))
-            .catch(() => false)
-        : Promise.resolve(false);
-
-    const mountIfServed = (url, importVendor, setter) => {
-      probe(url)
-        .then((served) => {
-          if (!served || cancelled) return null;
-          return importVendor();
-        })
-        .then((mod) => {
-          if (!mod || cancelled) return;
-          setter(() => mod);
-        })
-        .catch(() => undefined);
+    // Network I/O lives here at the wiring layer (ADR-0009); the probe result
+    // decision is made by the pure module.
+    const probe = (url) => {
+      const fetchFn = globalThis.fetch;
+      if (typeof fetchFn !== 'function') return Promise.resolve(false);
+      return fetchFn(url, { method: 'HEAD' })
+        .then(isVercelScriptResponse)
+        .catch(() => false);
     };
 
-    mountIfServed(
-      '/_vercel/speed-insights/script.js',
-      () => import('@vercel/speed-insights/react').then((m) => m.SpeedInsights),
-      setInsights,
-    );
-    mountIfServed(
-      '/_vercel/insights/script.js',
-      () => import('@vercel/analytics/react').then((m) => m.Analytics),
-      setAnalytics,
-    );
+    mountAnalyticsIfServed({
+      url: VERCEL_INSIGHTS_ROUTE,
+      probe,
+      importVendor: () => import('@vercel/speed-insights/react').then((m) => m.SpeedInsights),
+      setter: setInsights,
+      isCancelled: () => cancelled,
+    });
+    mountAnalyticsIfServed({
+      url: VERCEL_ANALYTICS_ROUTE,
+      probe,
+      importVendor: () => import('@vercel/analytics/react').then((m) => m.Analytics),
+      setter: setAnalytics,
+      isCancelled: () => cancelled,
+    });
 
     return () => {
       cancelled = true;
     };
-  }, [ready, Insights, Analytics]);
+  }, [ready]);
 
   if (!ready || (!Insights && !Analytics)) return null;
   return (

--- a/src/utils/analyticsProbe.js
+++ b/src/utils/analyticsProbe.js
@@ -1,0 +1,56 @@
+/**
+ * Pure decision module for the Vercel analytics gate (ADR-0009). Zero I/O —
+ * the network probe is injected by the wiring in DeferredAnalytics.jsx;
+ * every decision here is unit-spec'd in tests/unit/analyticsProbe.spec.js.
+ *
+ * Why the gate exists: only Vercel serves the /_vercel/ analytics script
+ * routes. On any other static host the SPA fallback answers with index.html,
+ * and the injected <script> then throws a parse error ("Unexpected token
+ * '<'"). Probe each route and only boot the integration whose script the
+ * platform actually serves — best-effort per integration, never an app error.
+ */
+export const VERCEL_INSIGHTS_ROUTE = '/_vercel/speed-insights/script.js';
+export const VERCEL_ANALYTICS_ROUTE = '/_vercel/insights/script.js';
+
+const JAVASCRIPT_MIME_TYPES = new Set([
+  'application/javascript',
+  'text/javascript',
+  'application/x-javascript',
+  'application/ecmascript',
+  'text/ecmascript',
+]);
+
+/**
+ * True only when the platform actually serves the script: a 2xx response
+ * whose media type is a JavaScript MIME type. fetch() resolves for 404/500
+ * too, and an error page must never count as served. The content-type is
+ * normalized (parameters split off, trimmed, lower-cased) so header
+ * variations cannot slip past the allowlist.
+ */
+export function isVercelScriptResponse(resp) {
+  if (!resp || !resp.ok) return false;
+  const mediaType = String(resp.headers?.get('content-type') || '')
+    .split(';')[0]
+    .trim()
+    .toLowerCase();
+  return JAVASCRIPT_MIME_TYPES.has(mediaType);
+}
+
+/**
+ * Boots a vendor integration only when its probe reports the route as
+ * served. Any vendor-chunk failure is swallowed (best-effort — never an app
+ * error), and isCancelled() stops the chain mid-flight after unmount.
+ */
+export function mountAnalyticsIfServed({ url, probe, importVendor, setter, isCancelled }) {
+  const cancelled = () => (isCancelled ? isCancelled() : false);
+  return probe(url)
+    .then((served) => {
+      if (!served || cancelled()) return null;
+      return importVendor();
+    })
+    .then((mod) => {
+      if (!mod || cancelled()) return;
+      setter(() => mod);
+    })
+    .catch(() => undefined);
+}

--- a/tests/unit/DeferredAnalytics-failure-speed.spec.jsx
+++ b/tests/unit/DeferredAnalytics-failure-speed.spec.jsx
@@ -30,6 +30,7 @@ function stubVercelFetch() {
     'fetch',
     vi.fn(() =>
       Promise.resolve({
+        ok: true,
         headers: { get: (h) => (h === 'content-type' ? 'application/javascript' : null) },
       }),
     ),

--- a/tests/unit/DeferredAnalytics-failure.spec.jsx
+++ b/tests/unit/DeferredAnalytics-failure.spec.jsx
@@ -30,6 +30,7 @@ function stubVercelFetch() {
     'fetch',
     vi.fn(() =>
       Promise.resolve({
+        ok: true,
         headers: { get: (h) => (h === 'content-type' ? 'application/javascript' : null) },
       }),
     ),

--- a/tests/unit/DeferredAnalytics.spec.jsx
+++ b/tests/unit/DeferredAnalytics.spec.jsx
@@ -26,6 +26,7 @@ function stubVercelFetch(contentType = 'application/javascript') {
     'fetch',
     vi.fn(() =>
       Promise.resolve({
+        ok: true,
         headers: { get: (h) => (h === 'content-type' ? contentType : null) },
       }),
     ),
@@ -174,6 +175,31 @@ describe('DeferredAnalytics — idle boot path', () => {
     expect(insightsRendered()).toBe(false);
     expect(analyticsRendered()).toBe(false);
     expect(harness.container.textContent).toBe('');
+  });
+
+  it('probes exactly the two Vercel script routes with a HEAD request', async () => {
+    stubIdleCallback();
+    renderAnalytics();
+    interact();
+    await fireIdle();
+    expect(globalThis.fetch).toHaveBeenCalledWith('/_vercel/speed-insights/script.js', {
+      method: 'HEAD',
+    });
+    expect(globalThis.fetch).toHaveBeenCalledWith('/_vercel/insights/script.js', {
+      method: 'HEAD',
+    });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('stays unmounted when no fetch global exists (probe cannot run)', async () => {
+    vi.stubGlobal('fetch', undefined);
+    stubIdleCallback();
+    renderAnalytics();
+    interact();
+    await fireIdle();
+    await act(async () => {});
+    expect(insightsRendered()).toBe(false);
+    expect(analyticsRendered()).toBe(false);
   });
 });
 

--- a/tests/unit/analyticsProbe.spec.js
+++ b/tests/unit/analyticsProbe.spec.js
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  VERCEL_INSIGHTS_ROUTE,
+  isVercelScriptResponse,
+  mountAnalyticsIfServed,
+} from '../../src/utils/analyticsProbe.js';
+
+describe('isVercelScriptResponse', () => {
+  const headersFor = (contentType) => ({ get: (h) => (h === 'content-type' ? contentType : null) });
+
+  it('accepts a 2xx response with a JavaScript content type', () => {
+    expect(
+      isVercelScriptResponse({ ok: true, headers: headersFor('application/javascript') }),
+    ).toBe(true);
+  });
+
+  it('accepts legacy JavaScript MIME types', () => {
+    for (const type of [
+      'text/javascript',
+      'application/x-javascript',
+      'application/ecmascript',
+      'text/ecmascript',
+    ]) {
+      expect(isVercelScriptResponse({ ok: true, headers: headersFor(type) })).toBe(true);
+    }
+  });
+
+  it('accepts mixed-case media types', () => {
+    expect(
+      isVercelScriptResponse({ ok: true, headers: headersFor('Application/JavaScript') }),
+    ).toBe(true);
+  });
+
+  it('accepts parameterized content types', () => {
+    expect(
+      isVercelScriptResponse({
+        ok: true,
+        headers: headersFor('application/javascript; charset=utf-8'),
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects a non-2xx response even when it reports JavaScript', () => {
+    expect(
+      isVercelScriptResponse({ ok: false, headers: headersFor('application/javascript') }),
+    ).toBe(false);
+  });
+
+  it('rejects unrelated types whose name merely contains "javascript"', () => {
+    expect(
+      isVercelScriptResponse({ ok: true, headers: headersFor('application/not-javascript') }),
+    ).toBe(false);
+  });
+
+  it('rejects a 2xx SPA-fallback HTML response', () => {
+    expect(isVercelScriptResponse({ ok: true, headers: headersFor('text/html') })).toBe(false);
+  });
+
+  it('rejects falsy, headerless, and empty-header responses', () => {
+    expect(isVercelScriptResponse(null)).toBe(false);
+    expect(isVercelScriptResponse({ ok: true, headers: null })).toBe(false);
+    expect(isVercelScriptResponse({ ok: true, headers: headersFor('') })).toBe(false);
+  });
+});
+
+describe('mountAnalyticsIfServed', () => {
+  const setup = (overrides = {}) => {
+    const importVendor = overrides.importVendor || vi.fn(() => Promise.resolve('vendor'));
+    const setter = overrides.setter || vi.fn();
+    const probe = overrides.probe || vi.fn(() => Promise.resolve(true));
+    const isCancelled = overrides.isCancelled || (() => false);
+    return { url: VERCEL_INSIGHTS_ROUTE, importVendor, setter, probe, isCancelled };
+  };
+
+  it('imports and mounts the vendor when its route is served', async () => {
+    const { importVendor, setter, probe } = setup();
+    await mountAnalyticsIfServed({ url: VERCEL_INSIGHTS_ROUTE, importVendor, setter, probe });
+    expect(probe).toHaveBeenCalledWith(VERCEL_INSIGHTS_ROUTE);
+    expect(importVendor).toHaveBeenCalledTimes(1);
+    expect(setter).toHaveBeenCalledTimes(1);
+    expect(setter.mock.calls[0][0]()).toBe('vendor');
+  });
+
+  it('never imports or mounts when the route is not served', async () => {
+    const { importVendor, setter, probe } = setup({ probe: vi.fn(() => Promise.resolve(false)) });
+    await mountAnalyticsIfServed({ url: VERCEL_INSIGHTS_ROUTE, importVendor, setter, probe });
+    expect(importVendor).not.toHaveBeenCalled();
+    expect(setter).not.toHaveBeenCalled();
+  });
+
+  it('stops the chain once cancelled, even when the route is served', async () => {
+    const { importVendor, setter, probe, isCancelled } = setup({ isCancelled: () => true });
+    await mountAnalyticsIfServed({
+      url: VERCEL_INSIGHTS_ROUTE,
+      importVendor,
+      setter,
+      probe,
+      isCancelled,
+    });
+    expect(importVendor).not.toHaveBeenCalled();
+    expect(setter).not.toHaveBeenCalled();
+  });
+
+  it('swallows a failing vendor chunk: no mount, no unhandled rejection', async () => {
+    const { importVendor, setter, probe } = setup({
+      importVendor: vi.fn(() => Promise.reject(new Error('offline'))),
+    });
+    await expect(
+      mountAnalyticsIfServed({ url: VERCEL_INSIGHTS_ROUTE, importVendor, setter, probe }),
+    ).resolves.toBeUndefined();
+    expect(setter).not.toHaveBeenCalled();
+  });
+
+  it('skips the setter when the import resolves to a falsy module', async () => {
+    const { importVendor, setter, probe } = setup({
+      importVendor: vi.fn(() => Promise.resolve(null)),
+    });
+    await mountAnalyticsIfServed({ url: VERCEL_INSIGHTS_ROUTE, importVendor, setter, probe });
+    expect(setter).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Re-issued as a PR so the change gets the full review pipeline (CI, CodeQL, CodeRabbit). The same commit was previously pushed straight to main (6d5319a) — this PR exists to give it the CodeRabbit review pass, and per the new AGENTS.md rule the re-issued content merges here.

- Only Vercel serves the /_vercel/ analytics script routes; on any other static host the SPA fallback answers with index.html and the injected script throws a parse error ('Unexpected token <').
- Probe each route (HEAD, content-type check) before booting each integration; stay unmounted off-Vercel.
- Also lint-ignore generated test-results/ and playwright-report/.