### PR TITLE
chore(node): pin engines.node to major 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": "22.x"
+    "node": ">=22.20 <23"
   },
   "packageManager": "pnpm@11.3.0",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": ">=22.13"
+    "node": "22.x"
   },
   "packageManager": "pnpm@11.3.0",
   "scripts": {


### PR DESCRIPTION
## What does this PR do?

Fixes the Vercel deployment warning: the \ngines.node\ range \>=22.13\ would auto-upgrade when a new major Node.js version ships. Narrowed to \>=22.20 <23\ — caps the major (no auto-upgrade to Node 23) and sets a 22.20 floor for dependency compatibility. Matches CI (\setup-node: 22\). The \pnpm-lock.yaml\ warning is already satisfied: pnpm 11.3.0 regenerates it byte-identically (lockfile schema stays at 9.0 by design).

## Screenshots / recordings

Not applicable — no UI changes.

## How to test

1. \pnpm install\ (frozen-lockfile passes unchanged)
2. \pnpm build\ succeeds
3. \pnpm verify\ runs the fast gate (lint + format + unit tests + structural checks + build)
4. CI runs the same checks on this PR (watch with \gh pr checks 124\)

## Checklist

- [x] \pnpm verify\ passes (lint + format + unit tests + structural checks + build)
- [x] \pnpm knip\ passes (no unused exports / files / dependencies)
- [x] No \.github/workflows/\ changes — \pnpm lint:workflows\ not required
- [x] No UI/viewport/interactivity changes — not applicable
- [x] No new inline \style={{}}\ objects