### PR TITLE
fix(ui): stop carousel images bleeding past the nav arrows

### DIFF
--- a/src/Components/Execom/TeamCarousel.jsx
+++ b/src/Components/Execom/TeamCarousel.jsx
@@ -1,4 +1,4 @@
-import { useRef, useCallback } from 'react';
+import { useRef, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { FaChevronLeft, FaChevronRight } from 'react-icons/fa6';
 import useCarousel from '../../hooks/useCarousel.js';
@@ -6,7 +6,7 @@ import { useViewportWidth } from '../../hooks/useViewportWidth.js';
 import BlurImage from '../BlurImage/BlurImage';
 import useCarouselKeyboard from '../../hooks/useCarouselKeyboard.js';
 import { copyFor } from '../../utils/carouselWrap.js';
-import { TEAM_CARD_SIZES } from '../../utils/breakpoints.js';
+import { TEAM_WIDE_MIN, TEAM_3COL_MIN, TEAM_2COL_MIN } from '../../utils/breakpoints.js';
 
 import '../Execom/custom.css';
 
@@ -66,8 +66,21 @@ function TeamCarousel({
   useCarouselKeyboard({ widgetId, instanceRef, wrapperRef: wrapRef });
 
   const containerClass = isDesktop
-    ? `hidden sm:block ${flatCube ? '' : 'max-w-[360px] mx-auto py-4'}`
+    ? `hidden sm:block ${flatCube ? 'px-12' : 'max-w-[360px] mx-auto py-4'}`
     : 'block sm:hidden max-w-[320px] mx-auto py-4';
+
+  // Responsive image sizes matching the actual slide width. The section is
+  // w-4/5 (80vw) at md+, w-5/6 at sm; the px-12 padding reserves 96px total
+  // so the edge cards stop short of the nav arrows. Cube/mobile cards are a
+  // single centered capped width (360px desktop / 320px mobile).
+  const cardSizes = useMemo(() => {
+    if (flatCube && isDesktop) {
+      if (width >= TEAM_WIDE_MIN) return 'calc((80vw - 168px) / 4)';
+      if (width >= TEAM_3COL_MIN) return 'calc((80vw - 144px) / 3)';
+      if (width >= TEAM_2COL_MIN) return 'calc((83.33vw - 116px) / 2)';
+    }
+    return isDesktop ? '360px' : '320px';
+  }, [width, flatCube, isDesktop]);
 
   // Card widths: desktop cube caps at 360px, mobile cube at 320px, desktop
   // flat scales 2-4 per view (~240-300px each). These sizes make 1x viewports
@@ -107,7 +120,7 @@ function TeamCarousel({
                   className={`object-cover ${d.name === 'Sebin Mathew' ? 'object-center' : 'object-top'} w-full h-full ${isDesktop ? 'card-hover' : ''} grayscale group-hover:filter-none transition-all duration-300`}
                   src={d.img}
                   srcSet={d.srcset}
-                  sizes={TEAM_CARD_SIZES}
+                  sizes={cardSizes}
                   blurSrc={d.blur}
                   alt={d.name}
                   loading="lazy"

--- a/src/Pages/LandingPage/HeroSection/HeroSection.jsx
+++ b/src/Pages/LandingPage/HeroSection/HeroSection.jsx
@@ -69,16 +69,6 @@ function HeroSection() {
           className={`h-[50%] w-[38%] relative top-[50vh] left-[10vw] max-[767px]:w-[80%] max-[767px]:top-[41vh] `}
         />
       </div>
-      {/* TEMP: Sentry test button — remove after verifying error tracking */}
-      <button
-        type="button"
-        onClick={() => {
-          throw new Error('This is your first error!');
-        }}
-        className="fixed bottom-4 right-4 z-50 rounded-full bg-red-600 px-4 py-2 text-sm font-semibold text-white"
-      >
-        Break the world
-      </button>
     </div>
   );
 }

--- a/src/Pages/LandingPages/Featuring.jsx
+++ b/src/Pages/LandingPages/Featuring.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useViewportWidth } from '../../hooks/useViewportWidth.js';
 import useCarousel from '../../hooks/useCarousel.js';
 import { FaChevronLeft, FaChevronRight } from 'react-icons/fa6';
@@ -7,7 +7,11 @@ import useDeviceProfile from '../../hooks/useLowPower.js';
 import BlurImage from '../../Components/BlurImage/BlurImage';
 import featuring from '../../assets/featuring.svg';
 import { echoSlides, carouselSlides } from '../../data/echoSlides.js';
-import { featuringSlidesPerView, DESKTOP_MIN, SMALL_SCREEN_MAX } from '../../utils/breakpoints.js';
+import {
+  featuringSlidesPerView,
+  FEATURING_2COL_MAX,
+  SMALL_SCREEN_MAX,
+} from '../../utils/breakpoints.js';
 import { copyFor } from '../../utils/carouselWrap.js';
 import useCarouselKeyboard from '../../hooks/useCarouselKeyboard.js';
 import './Featuring.css';
@@ -15,11 +19,25 @@ import './Featuring.css';
 function Featuring() {
   const { reducedMotion, lowPower } = useDeviceProfile();
   const disableAutoplay = reducedMotion || lowPower;
-  const noSlides = featuringSlidesPerView(useViewportWidth());
+  const viewportWidth = useViewportWidth();
+  const noSlides = featuringSlidesPerView(viewportWidth);
   const [activeSlide, setActiveSlide] = useState(0);
   const elRef = useRef(null);
   const carouselRef = useRef(null);
   const sectionRef = useRef(null);
+
+  // The .feat-swiper pads each side by 3.5rem (56px) so the slides stop short
+  // of the page edge and the prev/next arrows; the sizes string must match the
+  // actual slide width or the images render wider than their slide and bleed
+  // past the arrows. Computed from the same viewport width that decides the
+  // column count, so they can never drift apart.
+  const slideSizes = useMemo(() => {
+    const pad = 112; // 3.5rem x 2 sides
+    const gap = 50;
+    if (viewportWidth < SMALL_SCREEN_MAX) return `calc(100vw - ${pad}px)`;
+    if (viewportWidth < FEATURING_2COL_MAX) return `calc((100vw - ${pad}px - ${gap}px) / 2)`;
+    return `calc((100vw - ${pad}px - ${gap * 2}px) / 3)`;
+  }, [viewportWidth]);
 
   const { instanceRef, trackRef } = useCarousel({
     elRef,
@@ -112,7 +130,7 @@ function Featuring() {
                     className="h-full w-full rounded-2xl object-cover transition-all duration-300 shadow-xl hover:scale-105 hover:ring-2 hover:ring-white/50 hover:shadow-[0_0_25px_6px_rgba(255,255,255,0.25)]"
                     src={image}
                     srcSet={imageSet}
-                    sizes={`(min-width: ${DESKTOP_MIN}px) 33vw, (min-width: ${SMALL_SCREEN_MAX}px) 50vw, 90vw`}
+                    sizes={slideSizes}
                     blurSrc={blur}
                     alt={alt}
                     loading="lazy"

--- a/src/utils/breakpoints.js
+++ b/src/utils/breakpoints.js
@@ -27,8 +27,10 @@ export function isWideScreen(width) {
 }
 
 // ECHO carousel column policy (Featuring): 1 slide under 500px, 2 up to
-// 750px, 3 beyond.
-const FEATURING_2COL_MAX = 750;
+// 750px, 3 beyond. The breakpoint is exported too so the responsive sizes
+// string in Featuring.jsx matches the column count exactly (a mismatch makes
+// the images render wider than their slide and bleed toward the page edge).
+export const FEATURING_2COL_MAX = 750;
 export function featuringSlidesPerView(width) {
   if (width < SMALL_SCREEN_MAX) return 1;
   if (width < FEATURING_2COL_MAX) return 2;
@@ -36,10 +38,13 @@ export function featuringSlidesPerView(width) {
 }
 
 // Team carousel (Execom) column policy — flat desktop mode only; cube mode
-// is always 1. Derived from the same breakpoint constants.
-const TEAM_WIDE_MIN = 1280;
-const TEAM_3COL_MIN = 1024;
-const TEAM_2COL_MIN = 640;
+// is always 1. Derived from the same breakpoint constants. Exported so the
+// responsive sizes string in TeamCarousel matches the column count and
+// section width exactly (a mismatch makes the edge cards render wider than
+// their slide and bleed under the nav arrows).
+export const TEAM_WIDE_MIN = 1280;
+export const TEAM_3COL_MIN = 1024;
+export const TEAM_2COL_MIN = 640;
 export function teamSlidesPerView(width) {
   if (width >= TEAM_WIDE_MIN) return 4;
   if (width >= TEAM_3COL_MIN) return 3;
@@ -51,6 +56,3 @@ export function teamSlidesPerView(width) {
 export function teamGap(width) {
   return width >= TEAM_3COL_MIN ? 24 : 20;
 }
-
-// Team card responsive sizes string — built from the same breakpoints.
-export const TEAM_CARD_SIZES = `(min-width: ${TEAM_WIDE_MIN}px) 280px, (min-width: ${TEAM_2COL_MIN}px) 360px, 320px`;

--- a/tests/unit/breakpoints.spec.js
+++ b/tests/unit/breakpoints.spec.js
@@ -10,7 +10,10 @@ import {
   featuringSlidesPerView,
   teamSlidesPerView,
   teamGap,
-  TEAM_CARD_SIZES,
+  TEAM_WIDE_MIN,
+  TEAM_3COL_MIN,
+  TEAM_2COL_MIN,
+  FEATURING_2COL_MAX,
 } from '../../src/utils/breakpoints.js';
 
 describe('breakpoint constants agree with detectProfile CSS queries', () => {
@@ -73,10 +76,14 @@ describe('teamGap', () => {
   });
 });
 
-describe('TEAM_CARD_SIZES', () => {
-  it('contains 1280px, 640px, and 320px', () => {
-    expect(TEAM_CARD_SIZES).toContain('1280px');
-    expect(TEAM_CARD_SIZES).toContain('640px');
-    expect(TEAM_CARD_SIZES).toContain('320px');
+describe('column-policy breakpoints are exported for the sizes strings', () => {
+  it('featuring switches to 2 columns at 500, 3 at 750', () => {
+    expect(FEATURING_2COL_MAX).toBe(750);
+    expect(SMALL_SCREEN_MAX).toBe(500);
+  });
+  it('team columns switch at 640, 1024, and 1280', () => {
+    expect(TEAM_2COL_MIN).toBe(640);
+    expect(TEAM_3COL_MIN).toBe(1024);
+    expect(TEAM_WIDE_MIN).toBe(1280);
   });
 });


### PR DESCRIPTION
## What does this PR do?

Carousel slides were sized wider than the padded stage on every viewport, so images bled past the page edges and under the nav arrows.

- **Featuring**: `slideSizes` is now derived from the live viewport width via `useViewportWidth` (pad 112 = 2 x 3.5rem, gap 50), replacing the static `(min-width: DESKTOP_MIN) 33vw, (min-width: SMALL_SCREEN_MAX) 50vw, 90vw` srcset sizes — 90vw on mobile overflowed the padded track.
- **TeamCarousel**: the desktop flat container now has `px-12` (content stops 48px in, arrows occupy 0–40px); card sizes are computed per breakpoint — `calc((80vw - 168px) / 4)`, `calc((80vw - 144px) / 3)`, `calc((83.33vw - 116px) / 2)` (matching w-4/5 section, padding, and gaps), else fixed 360px/320px.
- **breakpoints.js**: exported `FEATURING_2COL_MAX`, `TEAM_WIDE_MIN`, `TEAM_3COL_MIN`, `TEAM_2COL_MIN`; removed the dead `TEAM_CARD_SIZES` constant. Specs updated.
- Removed the temp "Break the world" button from the hero (a leftover Sentry smoke-test button that threw on click — event-handler errors bypass React boundaries and it was never wired to anything).

## Screenshots / recordings

Not applicable — visual sizing fix; verified with the E2E carousel suites (`tests/carousels.spec.js`, `tests/carousel-lazy.spec.js`: 15 passed, 7 mobile-only skipped).

## How to test

1. `pnpm verify` (lint + format + unit + structural + build) — green locally
2. `pnpm exec playwright test tests/carousels.spec.js tests/carousel-lazy.spec.js` — carousel DOM contract unchanged
3. Preview and resize: images must stop inside the padded stage at 360/375/768/1024/1280px and never sit under the arrows

## Checklist

- [x] `pnpm verify` passes (lint + format + unit tests + structural checks + build)
- [x] `pnpm knip` passes
- [x] No `.github/workflows/` changes
- [x] No new inline `style={{}}` objects