### PR TITLE
fix(sentry): filter chunk and ResizeObserver noise from dashboard

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -19,6 +19,13 @@ import './index.css';
 // replay) is ~100KB and would inflate the initial bundle for every visitor.
 // Instead it is fetched on demand, only when a DSN is configured (production).
 // Most visits never configure a DSN, so they never download it.
+import {
+  SENTRY_IGNORE_ERRORS,
+  SENTRY_DENY_URLS,
+  shouldDropSentryEvent,
+  isIgnorableMessage,
+} from './utils/sentryFilter.js';
+
 let reportError = () => {};
 
 if (import.meta.env.VITE_SENTRY_DSN) {
@@ -34,8 +41,25 @@ if (import.meta.env.VITE_SENTRY_DSN) {
         tracesSampleRate: 0.2,
         replaysSessionSampleRate: 0,
         replaysOnErrorSampleRate: 1.0,
+        ignoreErrors: SENTRY_IGNORE_ERRORS,
+        denyUrls: SENTRY_DENY_URLS,
+        beforeSend(event, hint) {
+          if (shouldDropSentryEvent(event, hint)) return null;
+          return event;
+        },
       });
-      reportError = (error) => Sentry.captureException(error);
+      reportError = (error) => {
+        const msg = error?.message || (typeof error === 'string' ? error : '');
+        if (isIgnorableMessage(msg)) return;
+        if (
+          shouldDropSentryEvent(
+            { exception: { values: [{ value: msg }] } },
+            { originalException: error },
+          )
+        )
+          return;
+        Sentry.captureException(error);
+      };
     })
     // Best-effort: if the SDK fails to load, fall back to the console-only
     // behavior — never let telemetry break the app.

--- a/src/utils/sentryFilter.js
+++ b/src/utils/sentryFilter.js
@@ -1,0 +1,82 @@
+// Sentry event filtering — pure, testable. Keeps the dashboard free of
+// high-volume browser noise that is not actionable (ResizeObserver, chunk
+// reloads, extensions, aborted fetches). No runtime gate — just a beforeSend
+// hook wired in main.jsx.
+
+export const SENTRY_IGNORE_ERRORS = [
+  'ResizeObserver loop limit exceeded',
+  'ResizeObserver loop completed with undelivered notifications',
+  'ResizeObserver loop',
+  'Loading chunk',
+  'Loading CSS chunk',
+  'ChunkLoadError',
+  'Failed to fetch dynamically imported module',
+  'Importing a module script failed',
+  'AbortError',
+  'NetworkError when attempting to fetch resource',
+  'Non-Error promise rejection captured',
+  'Non-Error exception captured',
+  'cancelled',
+];
+
+export const SENTRY_DENY_URLS = [
+  /extensions\//i,
+  /^chrome-extension:\/\//i,
+  /^moz-extension:\/\//i,
+  /^safari-extension:\/\//i,
+  /^safari-web-extension:\/\//i,
+];
+
+/**
+ * Whether a raw error message/value should be ignored by Sentry.
+ * @param {string} value
+ * @returns {boolean}
+ */
+export function isIgnorableMessage(value) {
+  if (!value || typeof value !== 'string') return false;
+  return SENTRY_IGNORE_ERRORS.some((p) => value.includes(p));
+}
+
+/**
+ * Whether an event's URL should be denied (browser extensions).
+ * @param {string} url
+ * @returns {boolean}
+ */
+export function isDeniedUrl(url) {
+  if (!url || typeof url !== 'string') return false;
+  return SENTRY_DENY_URLS.some((re) => re.test(url));
+}
+
+/**
+ * Decide whether a Sentry event should be dropped in beforeSend.
+ * @param {object} event - Sentry event
+ * @param {object} hint - Sentry hint (originalException etc)
+ * @returns {boolean} true if the event should be dropped
+ */
+export function shouldDropSentryEvent(event, hint) {
+  // Extension frames — check culprit, request url, and stack frames
+  const urls = [
+    event.request?.url,
+    event.culprit,
+    ...(event.exception?.values?.flatMap((v) =>
+      (v.stacktrace?.frames || []).map((f) => f.filename),
+    ) || []),
+    ...(event.stacktrace?.frames || []).map((f) => f.filename),
+  ].filter(Boolean);
+  if (urls.some(isDeniedUrl)) return true;
+
+  // Message / exception value
+  const values = [
+    event.message,
+    ...(event.exception?.values || []).map((v) => v.value),
+    hint?.originalException?.message,
+    typeof hint?.originalException === 'string' ? hint.originalException : null,
+  ].filter(Boolean);
+  if (values.some(isIgnorableMessage)) return true;
+
+  // Transaction / breadcrumb noise from aborted fetches handled by retry logic
+  const excType = event.exception?.values?.[0]?.type;
+  if (excType === 'AbortError') return true;
+
+  return false;
+}

--- a/tests/unit/sentryFilter.spec.js
+++ b/tests/unit/sentryFilter.spec.js
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SENTRY_IGNORE_ERRORS,
+  SENTRY_DENY_URLS,
+  isIgnorableMessage,
+  isDeniedUrl,
+  shouldDropSentryEvent,
+} from '../../src/utils/sentryFilter.js';
+
+describe('sentryFilter', () => {
+  it('exports ignore lists', () => {
+    expect(SENTRY_IGNORE_ERRORS.length).toBeGreaterThan(5);
+    expect(SENTRY_DENY_URLS.length).toBeGreaterThan(2);
+  });
+
+  it('isIgnorableMessage matches chunk and ResizeObserver noise', () => {
+    expect(isIgnorableMessage('Loading chunk 123 failed')).toBe(true);
+    expect(isIgnorableMessage('ChunkLoadError: Loading chunk 5 failed')).toBe(true);
+    expect(isIgnorableMessage('ResizeObserver loop limit exceeded')).toBe(true);
+    expect(isIgnorableMessage('Failed to fetch dynamically imported module: ...')).toBe(true);
+    expect(isIgnorableMessage('Real TypeError: cannot read property')).toBe(false);
+    expect(isIgnorableMessage('')).toBe(false);
+    expect(isIgnorableMessage(null)).toBe(false);
+  });
+
+  it('isDeniedUrl matches extensions', () => {
+    expect(isDeniedUrl('chrome-extension://abc/background.js')).toBe(true);
+    expect(isDeniedUrl('moz-extension://xyz/content.js')).toBe(true);
+    expect(isDeniedUrl('https://focess-five.vercel.app/assets/index.js')).toBe(false);
+    expect(isDeniedUrl('')).toBe(false);
+    expect(isDeniedUrl(null)).toBe(false);
+  });
+
+  it('shouldDropSentryEvent drops extension frames', () => {
+    const event = {
+      request: { url: 'chrome-extension://abc/inject.js' },
+      exception: {
+        values: [
+          {
+            value: 'Error',
+            stacktrace: { frames: [{ filename: 'chrome-extension://abc/inject.js' }] },
+          },
+        ],
+      },
+    };
+    expect(shouldDropSentryEvent(event, {})).toBe(true);
+  });
+
+  it('shouldDropSentryEvent drops ignorable messages', () => {
+    const event = { exception: { values: [{ value: 'ResizeObserver loop limit exceeded' }] } };
+    expect(shouldDropSentryEvent(event, {})).toBe(true);
+    const ok = { exception: { values: [{ value: 'TypeError: x is not a function' }] } };
+    expect(shouldDropSentryEvent(ok, {})).toBe(false);
+  });
+
+  it('shouldDropSentryEvent drops AbortError type', () => {
+    const event = { exception: { values: [{ type: 'AbortError', value: 'Fetch is aborted' }] } };
+    expect(shouldDropSentryEvent(event, {})).toBe(true);
+  });
+
+  it('shouldDropSentryEvent checks hint originalException', () => {
+    const event = { exception: { values: [{ value: 'Error' }] } };
+    const hint = { originalException: new Error('Loading chunk 42 failed') };
+    expect(shouldDropSentryEvent(event, hint)).toBe(true);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes Sentry noise — **JAVASCRIPT-REACT-4** (`Failed to fetch dynamically imported module: Execom-CbBf9NVz.js`) and similar high-volume browser errors that are not actionable:

- `src/utils/sentryFilter.js` — pure filter module (unit-tested) with `SENTRY_IGNORE_ERRORS` / `SENTRY_DENY_URLS`, `isIgnorableMessage`, `isDeniedUrl`, `shouldDropSentryEvent`. Covers: `Loading chunk`, `ChunkLoadError`, `Failed to fetch dynamically imported module`, `ResizeObserver loop`, `AbortError`, extensions (`chrome-extension://`), etc.
- `src/main.jsx` — wires `ignoreErrors`, `denyUrls`, `beforeSend` into `Sentry.init` and makes `reportError` (used by `ErrorBoundary`) check the same filter before `captureException`. The chunk error from the old preview URL (`focces-48hra01ty.../assets/Execom-*.js`) is now dropped — `lazyWithRetry` already handles it via retry + one-time reload, so reporting it was duplicate noise.

Verified: `pnpm verify` green, 606 unit tests (7 new), `sentryFilter.spec.js` covers chunk/ResizeObserver/extension dropping.

## How to test

1. `pnpm verify`
2. `pnpm exec vitest run tests/unit/sentryFilter.spec.js`
3. After deploy, JAVASCRIPT-REACT-4 should stop appearing for stale chunk URLs; legitimate errors still report.

## Checklist

- [x] `pnpm verify` passes
- [x] No `.github/workflows/` changes
- [x] No new inline `style={{}}` objects
