### PR TITLE
refactor: extract focusTargets seam and toast policy

### DIFF
--- a/src/hooks/useContactForm.js
+++ b/src/hooks/useContactForm.js
@@ -6,6 +6,7 @@ import {
   resolveSendChannel,
   buildMailtoHref,
   resolveSubmissionOutcome,
+  toastAutoCloseMs,
 } from '../utils/contactSubmitLogic.js';
 import { loadContactDraft, saveContactDraft, clearContactDraft } from '../utils/contactDraft.js';
 
@@ -74,13 +75,16 @@ export default function useContactForm() {
     }
 
     toast.dismiss();
-    if (outcome.toastType === 'success') {
-      toast.success(outcome.message, { autoClose: 2000, ...TOAST_STYLE });
-    } else if (outcome.toastType === 'error') {
-      toast.error(outcome.message, { autoClose: 2000, ...TOAST_STYLE });
-    } else {
-      toast.info(outcome.message, { autoClose: 3000, ...TOAST_STYLE });
-    }
+    const showToast =
+      outcome.toastType === 'success'
+        ? toast.success
+        : outcome.toastType === 'error'
+          ? toast.error
+          : toast.info;
+    showToast(outcome.message, {
+      autoClose: toastAutoCloseMs(outcome.toastType ?? 'info'),
+      ...TOAST_STYLE,
+    });
 
     setIsSubmitting(false);
   };

--- a/src/hooks/useFocusRestore.js
+++ b/src/hooks/useFocusRestore.js
@@ -1,11 +1,19 @@
 import { useEffect, useRef } from 'react';
 import { deferToNextPaint } from '../utils/frameScheduler.js';
-import { findFocusableElements } from '../utils/overlayLifecycle.js';
+import {
+  resolveEntryFocusTarget,
+  resolveRestoreFocusTarget,
+  focusIfFocusable,
+} from '../utils/focusTargets.js';
 
 /**
  * Focused hook that captures focus prior to opening an overlay, focuses an
  * initial element, and restores focus back to the trigger or pre-open element
  * when the overlay closes or unmounts (WCAG 2.4.3 Focus Order).
+ *
+ * Target resolution lives in the pure seam utils/focusTargets.js — this hook
+ * only wires the open/close lifecycle and captures the previously focused
+ * element.
  *
  * @param {{
  *   isOpen: boolean,
@@ -38,42 +46,33 @@ export default function useFocusRestore({
       previouslyFocusedElementRef.current = doc.activeElement;
     }
 
+    const explicitRestoreTarget = restoreFocusRef?.current ?? null;
+
     // Focus entry: initialFocusRef -> initialFocusId -> first focusable in container
     const cancelEntry = deferToNextPaint(() => {
-      let targetToFocus = initialFocusRef?.current;
-      if (!targetToFocus && initialFocusId) {
-        targetToFocus = doc.getElementById(initialFocusId);
-      }
-      if (!targetToFocus) {
-        const container =
-          containerRef?.current || (containerId ? doc.getElementById(containerId) : null);
-        if (container) {
-          const focusables = findFocusableElements(container);
-          targetToFocus = focusables[0] || container;
-        }
-      }
-
-      if (targetToFocus && typeof targetToFocus.focus === 'function') {
-        targetToFocus.focus();
-      }
+      focusIfFocusable(
+        resolveEntryFocusTarget({
+          initialFocusRef,
+          initialFocusId,
+          containerRef,
+          containerId,
+          doc,
+        }),
+      );
     });
-
-    const explicitRestoreTarget = restoreFocusRef?.current;
 
     return () => {
       cancelEntry();
       // Restore focus on close / unmount
       deferToNextPaint(() => {
-        let restoreEl = explicitRestoreTarget;
-        if (!restoreEl && restoreFocusId) {
-          restoreEl = doc.getElementById(restoreFocusId);
-        }
-        if (!restoreEl) {
-          restoreEl = previouslyFocusedElementRef.current;
-        }
-        if (restoreEl && typeof restoreEl.focus === 'function') {
-          restoreEl.focus();
-        }
+        focusIfFocusable(
+          resolveRestoreFocusTarget({
+            explicitRestoreTarget,
+            restoreFocusId,
+            previouslyFocusedElement: previouslyFocusedElementRef.current,
+            doc,
+          }),
+        );
       });
     };
   }, [

--- a/src/utils/contactSubmitLogic.js
+++ b/src/utils/contactSubmitLogic.js
@@ -3,6 +3,25 @@ import { validateContactForm, isSpamSubmission } from './validateContactForm.js'
 export const CONTACT_EMAIL = 'Sebinmathew543@gmail.com';
 
 /**
+ * Pure decision: which toast autoClose delay applies for an outcome type?
+ * @param {'success' | 'error' | 'info'} toastType
+ * @returns {number} ms
+ */
+export function toastAutoCloseMs(toastType) {
+  return toastType === 'info' ? 3000 : 2000;
+}
+
+/**
+ * Pure decision: which toast method should run for a type? Returns the
+ * side-effect-free descriptor the hook applies.
+ * @param {'success' | 'error' | 'info'} toastType
+ * @returns {{ kind: 'success' | 'error' | 'info', message: string }}
+ */
+export function toastDescriptor(outcome) {
+  return { kind: outcome.toastType ?? 'info', message: outcome.message };
+}
+
+/**
  * Pure decision: which channel should a submission use?
  *
  * @param {{ onLine: boolean, serviceId?: string, templateId?: string, publicKey?: string }} env

--- a/src/utils/contactSubmitLogic.js
+++ b/src/utils/contactSubmitLogic.js
@@ -12,16 +12,6 @@ export function toastAutoCloseMs(toastType) {
 }
 
 /**
- * Pure decision: which toast method should run for a type? Returns the
- * side-effect-free descriptor the hook applies.
- * @param {'success' | 'error' | 'info'} toastType
- * @returns {{ kind: 'success' | 'error' | 'info', message: string }}
- */
-export function toastDescriptor(outcome) {
-  return { kind: outcome.toastType ?? 'info', message: outcome.message };
-}
-
-/**
  * Pure decision: which channel should a submission use?
  *
  * @param {{ onLine: boolean, serviceId?: string, templateId?: string, publicKey?: string }} env

--- a/src/utils/focusTargets.js
+++ b/src/utils/focusTargets.js
@@ -1,0 +1,79 @@
+import { findFocusableElements } from './overlayLifecycle.js';
+
+// Pure focus-target resolution for overlay lifecycle (entry + restore).
+//
+// Deletion test: delete this module and the ref/id/fallback chain duplicates
+// in useFocusRestore (entry path + restore path) scatter as two copies of the
+// same 4-branch resolution. One seam, two consumers, one spec file.
+
+/**
+ * Resolve the element to focus when an overlay opens.
+ * Priority: explicit ref > explicit id > first focusable inside container >
+ * container itself.
+ *
+ * @param {{
+ *   initialFocusRef?: { current?: HTMLElement | null },
+ *   initialFocusId?: string,
+ *   containerRef?: { current?: HTMLElement | null },
+ *   containerId?: string,
+ *   doc: Document
+ * }} params
+ * @returns {HTMLElement | null}
+ */
+export function resolveEntryFocusTarget({
+  initialFocusRef,
+  initialFocusId,
+  containerRef,
+  containerId,
+  doc,
+}) {
+  let target = initialFocusRef?.current ?? null;
+  if (!target && initialFocusId) {
+    target = doc.getElementById(initialFocusId);
+  }
+  if (!target) {
+    const container =
+      containerRef?.current || (containerId ? doc.getElementById(containerId) : null);
+    if (container) {
+      const focusables = findFocusableElements(container);
+      target = focusables[0] || container;
+    }
+  }
+  return target;
+}
+
+/**
+ * Resolve the element to focus when an overlay closes.
+ * Priority: explicit restore ref captured at open > explicit id > previously
+ * focused element.
+ *
+ * @param {{
+ *   explicitRestoreTarget?: HTMLElement | null,
+ *   restoreFocusId?: string,
+ *   previouslyFocusedElement?: HTMLElement | null,
+ *   doc: Document
+ * }} params
+ * @returns {HTMLElement | null}
+ */
+export function resolveRestoreFocusTarget({
+  explicitRestoreTarget,
+  restoreFocusId,
+  previouslyFocusedElement,
+  doc,
+}) {
+  if (explicitRestoreTarget) return explicitRestoreTarget;
+  if (restoreFocusId) return doc.getElementById(restoreFocusId);
+  return previouslyFocusedElement ?? null;
+}
+
+/**
+ * Focus an element if it is present and focusable. Null-safe.
+ * @param {HTMLElement | null | undefined} el
+ */
+export function focusIfFocusable(el) {
+  if (el && typeof el.focus === 'function') {
+    el.focus();
+    return true;
+  }
+  return false;
+}

--- a/tests/unit/focusTargets.spec.js
+++ b/tests/unit/focusTargets.spec.js
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  resolveEntryFocusTarget,
+  resolveRestoreFocusTarget,
+  focusIfFocusable,
+} from '../../src/utils/focusTargets.js';
+import * as overlayLifecycle from '../../src/utils/overlayLifecycle.js';
+
+describe('focusTargets', () => {
+  const doc = {
+    getElementById: vi.fn((id) => (id === 'known' ? { id, focus: vi.fn() } : null)),
+  };
+
+  describe('resolveEntryFocusTarget', () => {
+    it('prefers explicit ref over id and container', () => {
+      const refEl = { focus: vi.fn() };
+      const target = resolveEntryFocusTarget({
+        initialFocusRef: { current: refEl },
+        initialFocusId: 'known',
+        doc,
+      });
+      expect(target).toBe(refEl);
+    });
+
+    it('falls back to id when ref empty', () => {
+      const target = resolveEntryFocusTarget({
+        initialFocusRef: { current: null },
+        initialFocusId: 'known',
+        doc,
+      });
+      expect(target.id).toBe('known');
+    });
+
+    it('falls back to first focusable in container when no ref/id', () => {
+      const first = { focus: vi.fn() };
+      const spy = vi.spyOn(overlayLifecycle, 'findFocusableElements').mockReturnValue([first]);
+      const container = { tag: 'container' };
+      const target = resolveEntryFocusTarget({
+        initialFocusRef: { current: null },
+        initialFocusId: null,
+        containerRef: { current: container },
+        doc,
+      });
+      expect(target).toBe(first);
+      spy.mockRestore();
+    });
+
+    it('falls back to container itself when no focusables inside', () => {
+      const spy = vi.spyOn(overlayLifecycle, 'findFocusableElements').mockReturnValue([]);
+      const container = { tag: 'container', focus: vi.fn() };
+      const target = resolveEntryFocusTarget({
+        initialFocusRef: { current: null },
+        initialFocusId: null,
+        containerRef: { current: container },
+        doc,
+      });
+      expect(target).toBe(container);
+      spy.mockRestore();
+    });
+
+    it('uses containerId when no containerRef', () => {
+      doc.getElementById.mockImplementation((id) => (id === 'cont' ? { id: 'cont' } : null));
+      const spy = vi.spyOn(overlayLifecycle, 'findFocusableElements').mockReturnValue([]);
+      const target = resolveEntryFocusTarget({
+        initialFocusRef: { current: null },
+        initialFocusId: null,
+        containerId: 'cont',
+        doc,
+      });
+      expect(target).toEqual({ id: 'cont' });
+      spy.mockRestore();
+      doc.getElementById.mockImplementation((id) =>
+        id === 'known' ? { id, focus: vi.fn() } : null,
+      );
+    });
+
+    it('returns null when nothing resolvable', () => {
+      const target = resolveEntryFocusTarget({
+        initialFocusRef: { current: null },
+        initialFocusId: 'missing',
+        doc,
+      });
+      expect(target).toBeNull();
+    });
+  });
+
+  describe('resolveRestoreFocusTarget', () => {
+    it('returns explicit restore target first', () => {
+      const el = { focus: vi.fn() };
+      expect(
+        resolveRestoreFocusTarget({
+          explicitRestoreTarget: el,
+          restoreFocusId: 'known',
+          previouslyFocusedElement: null,
+          doc,
+        }),
+      ).toBe(el);
+    });
+
+    it('falls back to id then previous element then null', () => {
+      const prev = { focus: vi.fn() };
+      expect(
+        resolveRestoreFocusTarget({
+          explicitRestoreTarget: null,
+          restoreFocusId: 'known',
+          previouslyFocusedElement: prev,
+          doc,
+        }).id,
+      ).toBe('known');
+      expect(
+        resolveRestoreFocusTarget({
+          explicitRestoreTarget: null,
+          restoreFocusId: null,
+          previouslyFocusedElement: prev,
+          doc,
+        }),
+      ).toBe(prev);
+      expect(
+        resolveRestoreFocusTarget({
+          explicitRestoreTarget: null,
+          restoreFocusId: null,
+          previouslyFocusedElement: null,
+          doc,
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe('focusIfFocusable', () => {
+    it('focuses element with focus function and returns true', () => {
+      const el = { focus: vi.fn() };
+      expect(focusIfFocusable(el)).toBe(true);
+      expect(el.focus).toHaveBeenCalledTimes(1);
+    });
+    it('returns false for null or non-focusable', () => {
+      expect(focusIfFocusable(null)).toBe(false);
+      expect(focusIfFocusable({})).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

**Deepening round 3 — overlay focus seam + contact toast policy:**

- **`src/utils/focusTargets.js`** — pure seam for focus-target resolution. `useFocusRestore.js` had the same ref > id > container-fallback chain duplicated twice (entry path + restore path). Extracted `resolveEntryFocusTarget` / `resolveRestoreFocusTarget` / `focusIfFocusable` (each CC ≤4, CRAP <8 at full coverage). The hook is now pure lifecycle wiring — matches the headless-hook best practice (Tour Kit / React Aria pattern): the accessible path (focus restore) lives in the hook, not each consumer.
- **`contactSubmitLogic.js`** — added `toastAutoCloseMs(toastType)` pure policy (info=3000, else 2000). `useContactForm.js` toast branch collapsed from if/else-if/else with hardcoded delays to one descriptor lookup. Delays can no longer drift between branches.
- **`tests/unit/focusTargets.spec.js`** — 10 tests covering all resolution priorities and null paths.

Verified: `pnpm verify` green, all unit tests pass.

## How to test

1. `pnpm verify`
2. `pnpm exec vitest run tests/unit/focusTargets.spec.js tests/unit/useFocusRestore.spec.jsx tests/unit/useContactForm.spec.jsx`

## Checklist

- [x] `pnpm verify` passes
- [x] No `.github/workflows/` changes
- [x] No new inline `style={{}}` objects
