### PR TITLE
test: boundary specs for spin tracker gap and navSpy routes

### DIFF
--- a/tests/unit/easterEggLogic.spec.js
+++ b/tests/unit/easterEggLogic.spec.js
@@ -104,4 +104,22 @@ describe('createSpinTracker — default clock', () => {
     vi.setSystemTime(1100);
     expect(tracker.register()).toBe(true);
   });
+
+  it('register returns false while below target even with exact-gap spacing', () => {
+    const tracker = createSpinTracker({ target: 3, gap: 800 });
+    expect(tracker.register(0)).toBe(false);
+    expect(tracker.register(800)).toBe(false);
+  });
+
+  it('spin arriving exactly at the gap boundary keeps the run alive (not >)', () => {
+    const tracker = createSpinTracker({ target: 2, gap: 800 });
+    tracker.register(0);
+    expect(tracker.register(800)).toBe(true);
+  });
+
+  it('spin arriving 1ms past the gap resets the count', () => {
+    const tracker = createSpinTracker({ target: 2, gap: 800 });
+    tracker.register(0);
+    expect(tracker.register(801)).toBe(false);
+  });
 });

--- a/tests/unit/navSpy.spec.js
+++ b/tests/unit/navSpy.spec.js
@@ -240,3 +240,29 @@ describe('resolveLogoAction — where the logo click goes', () => {
     expect(resolveLogoAction('/')).toEqual({ type: 'scroll-top' });
   });
 });
+
+describe('pickOnViewport - route awareness edges', () => {
+  it('returns contact on the /contact route without reading the DOM', () => {
+    const doc = { getElementById: vi.fn(), documentElement: {} };
+    expect(
+      pickOnViewport({
+        sectionIds: ['home'],
+        pathname: '/contact',
+        win: { scrollY: 0, innerHeight: 800 },
+        doc,
+      }),
+    ).toBe('contact');
+  });
+
+  it('returns null on unknown routes (e.g. /events)', () => {
+    const doc = { getElementById: vi.fn(), documentElement: {} };
+    expect(
+      pickOnViewport({
+        sectionIds: ['home'],
+        pathname: '/events',
+        win: { scrollY: 0, innerHeight: 800 },
+        doc,
+      }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

**Mutation follow-up round 2 — gap/boundary mutants in spin tracker + navSpy route edges:**

- `easterEggLogic.spec.js` (11 → 14 tests) — kills surviving `>` vs `>=` and reset-path mutants in `createSpinTracker.register`: exact-gap boundary keeps run alive, 1ms past gap resets, below-target never fires.
- `navSpy.spec.js` (19 → 21 tests) — covers `pickOnViewport` route edges: `/contact` short-circuit (no DOM read), unknown-route null.

## How to test

1. `pnpm verify` — green
2. `pnpm exec vitest run tests/unit/easterEggLogic.spec.js tests/unit/navSpy.spec.js`

## Checklist

- [x] `pnpm verify` passes
- [x] Test-only change
