### PR TITLE
ci: align Renovate with pnpm minimum-release-age policy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["config:recommended"],
   "dependencyDashboard": true,
   "lockFileMaintenance": { "enabled": true },
+  "minimumReleaseAge": "1 day",
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
## What does this PR do?

Aligns Renovate with pnpm's `minimumReleaseAge` supply-chain policy (`"minimumReleaseAge": "1 day"`).

**Problem:** Renovate proposed `eslint@10.9.0` ~15h after publish; every CI install gate rejects it with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` (24h cutoff). PR #119 was closed for this and #139 recreated identically — the loop repeats until the release ages out.

**Fix:** one line in `renovate.json`. Renovate now holds bumps until releases are ≥1 day old, matching the install gate, so it never proposes a version CI will reject.

(#139 stays open — it turns green at 13:07 UTC today when eslint@10.9.0 reaches 24h, then automerges via the existing minor/patch rule.)

## Checklist

- [x] Config-only change
- [x] No code changes
