### PR TITLE
perf: EventCard memoization + scroll-gate AboutUs/Events

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -80,18 +80,26 @@ function App() {
       <main id="main-content" tabIndex={-1}>
         {pageH1}
         <HeroSection />
-        <Suspense fallback={<SectionSkeleton height="100vh" label="Loading about" />}>
-          <AboutUs />
-        </Suspense>
+        {/* The cube section is scroll-gated too: its chunk (AboutUs + cube
+            physics + celebration) only downloads when the user approaches it.
+            The wrapper owns the section id, so anchors/scrollspy/tests still
+            find it. */}
+        <ScrollGate id="about" placeholderHeight="100vh" label="Loading about">
+          <Suspense fallback={<SectionSkeleton height="100vh" label="Loading about" />}>
+            <AboutUs />
+          </Suspense>
+        </ScrollGate>
         {/* Carousel sections are scroll-gated: the hand-rolled carousel chunk
             only downloads when the section approaches the viewport. The wrapper
             owns the section id, so anchors/scrollspy/tests still find it. */}
         <ScrollGate id="featuring" placeholderHeight="95vh" label="Loading featuring">
           <Featuring />
         </ScrollGate>
-        <Suspense fallback={<SectionSkeleton height="100vh" label="Loading events" />}>
-          <Events />
-        </Suspense>
+        <ScrollGate id="events" placeholderHeight="120vh" label="Loading events">
+          <Suspense fallback={<SectionSkeleton height="100vh" label="Loading events" />}>
+            <Events />
+          </Suspense>
+        </ScrollGate>
         <ScrollGate id="execom" placeholderHeight="110vh" label="Loading team">
           <Execom />
         </ScrollGate>

--- a/src/Components/AboutUs/AboutUs.jsx
+++ b/src/Components/AboutUs/AboutUs.jsx
@@ -122,10 +122,7 @@ function AboutUs() {
   useEffect(() => () => celebrationCleanupRef.current?.(), []);
 
   return (
-    <div
-      className="mx-6 mt-14 lg:mx-1 flex flex-col justify-center text-white lg:px-44 scroll-mt-24"
-      id="about"
-    >
+    <div className="mx-6 mt-14 lg:mx-1 flex flex-col justify-center text-white lg:px-44 scroll-mt-24">
       <div className="md:text-xl lg:text-2xl mb-4 md:mb-6 lg:mb-8 flex items-center relative">
         <div className="inline-block w-5 h-16 bg-[#4f4f54] relative" data-aos="flip-up"></div>
         <h2

--- a/src/Pages/EventPage/EventCard.jsx
+++ b/src/Pages/EventPage/EventCard.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import Modal from './Modal';
 import { prioritizeAssetFetch } from '../../utils/priorityScheduler.js';
@@ -10,7 +10,7 @@ import BlurImage from '../../Components/BlurImage/BlurImage';
  * Accessible interactive trigger for photo gallery expansion.
  * Coordinates role="button", tabIndex, keyboard activation (Enter/Space), and accessible labels.
  */
-function GalleryTrigger({ onOpen, label, hasPopup, className, children }) {
+function GalleryTrigger({ onOpen, label, hasPopup = false, className = '', children = null }) {
   const handleKeyDown = onActivationKey(onOpen);
   return (
     <div
@@ -35,12 +35,6 @@ GalleryTrigger.propTypes = {
   children: PropTypes.node,
 };
 
-GalleryTrigger.defaultProps = {
-  hasPopup: false,
-  className: '',
-  children: null,
-};
-
 /**
  * EventCard — one responsive card for every breakpoint.
  *
@@ -50,22 +44,28 @@ GalleryTrigger.defaultProps = {
  * Tailwind responsive variants, so Eventpage no longer tracks window width
  * (and its per-resize re-render is gone with it).
  */
-function EventCard({ Events, priority, reverse }) {
+function EventCard({ Events, priority = false, reverse = false }) {
   const [Expanding, setExpanding] = useState(false);
-  const handleOpenGallery = () => setExpanding(true);
+  // INP: every callback/allocation below used to be re-created on each render
+  // of the events list (e.g. a sibling card opening its modal re-renders all
+  // cards). Memoized so a parent re-render does no per-card allocation work
+  // and React can bail out of prop-identity churn.
+  const handleOpenGallery = useCallback(() => setExpanding(true), []);
+  const handleCloseGallery = useCallback(() => setExpanding(false), []);
 
   // photos are { url, srcset } pairs (see src/utils/eventPhotos.js) — no more
   // parallel images[i] ↔ imageSets[i] index math to get wrong.
-  const photos = Events.photos || [];
+  const photos = useMemo(() => Events.photos || [], [Events.photos]);
   const primary = photos[0];
+  const modalImages = useMemo(() => photos.map((photo) => photo.url), [photos]);
 
   // Images are already cached by the service worker (images-cache-v2,
   // CacheFirst) — the removed imageCacheManager fetched + stored every photo
   // a second time in its own cache. Only warm the browser's HTTP cache for
   // the photos the user is about to look at (modal open intent), on demand.
-  const handleInteraction = () => {
+  const handleInteraction = useCallback(() => {
     photos.forEach((photo) => prioritizeAssetFetch(photo.url));
-  };
+  }, [photos]);
 
   return (
     <div
@@ -136,11 +136,7 @@ function EventCard({ Events, priority, reverse }) {
         )}
       </div>
 
-      <Modal
-        images={photos.map((photo) => photo.url)}
-        open={Expanding}
-        onClose={() => setExpanding(false)}
-      />
+      <Modal images={modalImages} open={Expanding} onClose={handleCloseGallery} />
 
       {/* Details Section */}
       <div className="w-full md:w-1/2 flex flex-col justify-between text-white space-y-3 md:space-y-4">
@@ -195,11 +191,6 @@ EventCard.propTypes = {
   }).isRequired,
   priority: PropTypes.bool,
   reverse: PropTypes.bool,
-};
-
-EventCard.defaultProps = {
-  priority: false,
-  reverse: false,
 };
 
 export default EventCard;

--- a/src/Pages/LandingPages/Events.jsx
+++ b/src/Pages/LandingPages/Events.jsx
@@ -6,10 +6,7 @@ import { WIDE_SCREEN_MIN, DESKTOP_MIN } from '../../utils/breakpoints.js';
 
 function Events() {
   return (
-    <section
-      className="bg-[#0b0b0c] text-white py-16 px-4 md:px-12 relative overflow-hidden scroll-mt-24"
-      id="events"
-    >
+    <section className="bg-[#0b0b0c] text-white py-16 px-4 md:px-12 relative overflow-hidden scroll-mt-24">
       {/* Background Decorative Neon Glows */}
       <div className="absolute top-1/4 -left-32 w-96 h-96 bg-cyan-600/15 blur-[120px] rounded-full pointer-events-none" />
       <div className="absolute bottom-10 -right-32 w-96 h-96 bg-purple-600/15 blur-[120px] rounded-full pointer-events-none" />


### PR DESCRIPTION
## What does this PR do?

**Two perf commits:**

1. **`perf(inp): memoize EventCard allocations and callbacks`** (`EventCard.jsx`)
   - `photos`, `modalImages` via `useMemo`; `handleOpenGallery`/`handleCloseGallery`/`handleInteraction` via `useCallback`
   - Before: every parent re-render (e.g. sibling card opening its modal re-renders the events list) re-ran `photos.map()` for the Modal prop and re-created all handlers — per-card allocation churn on the interaction path
   - Also converts `GalleryTrigger`/`EventCard` from deprecated React 19 `defaultProps` to default parameter values

2. **`perf: scroll-gate AboutUs and Events chunks`** (`App.jsx`)
   - Extends the existing ScrollGate treatment (already on Featuring + Execom) to the remaining two lazy sections
   - The AboutUs chunk (cube physics + celebration modules) and the Events chunk now download only when the user scrolls near them, instead of firing at boot via their Suspense boundaries
   - Wrapper owns the section id (`about`/`events`) so anchors/scrollspy/E2E selectors still resolve

**Verified:** `pnpm verify` green; targeted E2E — home (18 passed incl. cube touch rotation), events, navigation, accessibility axe scan (16 passed) all pass with the new gates.

## How to test

1. `pnpm verify`
2. `pnpm exec playwright test tests/home.spec.js tests/events.spec.js --project=chromium`
3. Network tab on fresh load: AboutUs/Events chunks must NOT appear until scrolled near

## Checklist

- [x] `pnpm verify` passes
- [x] No `.github/workflows/` changes
- [x] No new inline `style={{}}` objects
