### PR TITLE
ci: add Scorecard, Harden-Runner and dependency review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      # StepSecurity Harden-Runner — records every outbound call the job
+      # makes and flags unexpected destinations (supply-chain exfiltration
+      # detection). audit mode = observe only; flip to `block` once a week of
+      # logs confirms nothing legitimate is flagged.
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
@@ -90,6 +99,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
@@ -125,6 +139,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
@@ -212,6 +231,25 @@ jobs:
       contents: read
       pull-requests: read
 
+  # Reviews the dependency diff a PR introduces (unlike `pnpm audit`, which
+  # only sees the current lockfile). Fails PRs that add high/critical
+  # vulnerabilities or incompatible license changes.
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+
   # Tell Vercel when the GitHub checks finish so deployments that "wait for
   # CI" don't hang. The `name` below must match the check name configured in
   # Vercel → Project → Settings → Git → Deployment settings → "Wait for CI
@@ -220,7 +258,7 @@ jobs:
   notify-vercel:
     name: Notify Vercel
     if: always()
-    needs: [lint-and-build, e2e, probes, commitlint]
+    needs: [lint-and-build, e2e, probes, commitlint, dependency-review]
     runs-on: ubuntu-latest
     permissions:
       # The status action calls the Actions jobs API (actions: read) and
@@ -243,7 +281,8 @@ jobs:
             "${{ needs.lint-and-build.result }}" \
             "${{ needs.e2e.result }}" \
             "${{ needs.probes.result }}" \
-            "${{ needs.commitlint.result }}"; do
+            "${{ needs.commitlint.result }}" \
+            "${{ needs.dependency-review.result }}"; do
             if [ "$r" != "success" ] && [ "$r" != "skipped" ]; then
               failed=1
             fi
@@ -268,7 +307,7 @@ jobs:
   notify-on-failure:
     name: Notify on failure
     if: failure() && github.event_name == 'pull_request'
-    needs: [lint-and-build, e2e, probes, commitlint]
+    needs: [lint-and-build, e2e, probes, commitlint, dependency-review]
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -285,5 +324,5 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: `🚨 **CI failed** on \`${sha}\` — [view the run](${run}).\n\n` +
-                `@${context.actor} one of the checks (lint, format, unit, specs, build, E2E, probes, commitlint) is red, so the merge gate stays closed.`,
+                `@${context.actor} one of the checks (lint, format, unit, specs, build, E2E, probes, commitlint, dependency review) is red, so the merge gate stays closed.`,
             });

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,60 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+# OpenSSF Scorecard — supply-chain posture audit (branch protection, action
+# pinning, token permissions, dependency policy). Results publish to the
+# OSSF API (enables the scorecard badge) and upload as SARIF so findings
+# appear under Security → Code scanning alongside CodeQL.
+name: Scorecard supply-chain security
+
+on:
+  # Run weekly and on every push to main; dispatch lets us re-score on demand.
+  branch_protection_rule:
+  schedule:
+    - cron: '40 2 * * 4'
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Restrict the top-level token; the job widens only what Scorecard needs.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      # Needed to publish results to the OSSF badge/API (via OIDC).
+      id-token: write
+      # Needed to upload SARIF to code scanning.
+      security-events: write
+      actions: read
+      checks: read
+      contents: read
+      issues: read
+      pull-requests: read
+    steps:
+      # persist-credentials: false — Scorecard flags repos whose checkout
+      # leaves the runner token in .git/config.
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary
Completes the supply-chain hardening set (CodeQL was already live via default setup):

1. **OpenSSF Scorecard** — new .github/workflows/scorecard.yml. Weekly cron + push to main + dispatch. Publishes results to the OSSF API (badge) and uploads SARIF to code scanning.
2. **StepSecurity Harden-Runner** — step-security/harden-runner@v2 (gress-policy: audit) added right after checkout in the three jobs that install/run untrusted packages: Lint & Build, E2E, Probes. Start in audit mode; flip to lock after reviewing a week of logs at app.stepsecurity.io.
3. **Dependency review** — new dependency-review job in ci.yml on PRs only: fails when a PR introduces high/critical vulnerabilities (complements pnpm audit, which only sees the current lockfile). Wired into 
otify-vercel + 
otify-on-failure gates so Vercel waits for it too.

## Verification
- \pnpm lint:workflows\ (actionlint 1.7.12 + shellcheck 0.11) passes locally.
- No changes to application code; foces-webv23 untouched.

## Post-merge follow-ups
- Trigger Scorecard once via Actions → *Scorecard supply-chain security* → Run workflow to get the first score + badge.
- After ~1 week of Harden-Runner audit logs, switch the three steps to \gress-policy: block\.