### PR TITLE
ci: fix scorecard action version pins

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -41,7 +41,9 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        # No floating major tag exists for this action — pin the patch
+        # release; dependabot bumps it weekly.
+        uses: ossf/scorecard-action@v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
@@ -55,6 +57,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
Follow-up to #147: the Scorecard workflow failed at action resolution on its first run.

- \ossf/scorecard-action@v2\ → \@v2.4.4\ — the action publishes only patch tags; no floating \2\ major tag exists.
- \github/codeql-action/upload-sarif@v3\ → \@v4\ — v3 tags are gone in 2026.

Both verified against the live tag lists. \pnpm lint:workflows\ passes.