### PR TITLE
perf(boot): scroll-only chunk deferral + shell-only SW precache

### DIFF
--- a/src/Components/ScrollGate/ScrollGate.jsx
+++ b/src/Components/ScrollGate/ScrollGate.jsx
@@ -60,10 +60,16 @@ export default function ScrollGate({ id, placeholderHeight = '110vh', label, chi
     let io = null;
     const mount = () => setMounted(true);
 
-    // 1. IntersectionObserver: fires reliably during real (incremental) scrolling
+    // 1. IntersectionObserver: fires reliably during real (incremental)
+    //    scrolling. The callback honours the boot rule too — rootMargin
+    //    extends the zone 0.5 viewports below the fold, so without the guard
+    //    IO would mount a just-below-fold section the instant it observes.
+    //    (Observer is recreated once when `armed` flips.)
     io = new IntersectionObserver(
       ([entry]) => {
-        if (entry.isIntersecting) {
+        if (!entry.isIntersecting) return;
+        const ok = armed || shouldMountAtBoot(entry.boundingClientRect.top, window.innerHeight);
+        if (ok) {
           mount();
           io?.disconnect();
         }

--- a/src/Components/ScrollGate/ScrollGate.jsx
+++ b/src/Components/ScrollGate/ScrollGate.jsx
@@ -2,8 +2,7 @@ import { Suspense, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import SectionSkeleton from '../SectionSkeleton/SectionSkeleton';
 import { isDesktopViewport } from '../../utils/breakpoints.js';
-import useExperienceCapabilities from '../../hooks/useExperienceCapabilities.js';
-import { shouldMountSection, scheduleIdleMount } from './scrollGateLogic.js';
+import { shouldMountAtBoot, shouldMountSection } from './scrollGateLogic.js';
 
 // Real section heights, cached after first mount so the placeholder matches
 // the real content on subsequent visits (no layout shift on return). Keyed by
@@ -32,10 +31,20 @@ function viewportBucket() {
  */
 export default function ScrollGate({ id, placeholderHeight = '110vh', label, children }) {
   const [mounted, setMounted] = useState(false);
+  // Before the first user scroll, below-fold sections stay deferred (boot
+  // must not download/evaluate their chunks). The first scroll event arms the
+  // normal pre-load margin. Anchor jumps still work: the wrapper owns the
+  // section id, so navigationCoordinator finds it, scrolls, and the resulting
+  // scroll event arms the gate before content is needed.
+  const [armed, setArmed] = useState(false);
   const wrapRef = useRef(null);
-  // The slowNetwork gate for the idle pre-mount lives in the experience-tier
-  // matrix — scrollGate is the capability.
-  const { scrollGate } = useExperienceCapabilities();
+
+  useEffect(() => {
+    if (armed) return;
+    const arm = () => setArmed(true);
+    window.addEventListener('scroll', arm, { passive: true, once: true });
+    return () => window.removeEventListener('scroll', arm);
+  }, [armed]);
 
   useEffect(() => {
     if (mounted) return;
@@ -63,11 +72,15 @@ export default function ScrollGate({ id, placeholderHeight = '110vh', label, chi
     );
     io.observe(el);
 
-    // 2. Programmatic jump fallback
+    // 2. Programmatic jump fallback — boot rule before first scroll, full
+    //    margin once armed.
     let rafId = 0;
     const checkPosition = () => {
-      const rect = el.getBoundingClientRect();
-      if (shouldMountSection(rect.top, window.innerHeight, MOUNT_MARGIN_VIEWPORTS)) mount();
+      const top = el.getBoundingClientRect().top;
+      const ok = armed
+        ? shouldMountSection(top, window.innerHeight, MOUNT_MARGIN_VIEWPORTS)
+        : shouldMountAtBoot(top, window.innerHeight);
+      if (ok) mount();
     };
     const onScroll = () => {
       if (rafId) cancelAnimationFrame(rafId);
@@ -78,21 +91,13 @@ export default function ScrollGate({ id, placeholderHeight = '110vh', label, chi
 
     checkPosition();
 
-    // 3. Idle background pre-mounting once on-screen content is loaded
-    const cancelIdle = scheduleIdleMount({
-      onMount: mount,
-      delayMs: 2200,
-      slowNetwork: !scrollGate,
-    });
-
     return () => {
       io?.disconnect();
       if (rafId) cancelAnimationFrame(rafId);
       window.removeEventListener('scroll', onScroll);
       window.removeEventListener('resize', onScroll);
-      cancelIdle();
     };
-  }, [mounted, scrollGate]);
+  }, [mounted, armed]);
 
   // Cache the real height once the section's content lands. ResizeObserver —
   // not a mount-timed read — because when `mounted` flips, the inner lazy

--- a/src/Components/ScrollGate/scrollGateLogic.js
+++ b/src/Components/ScrollGate/scrollGateLogic.js
@@ -18,15 +18,17 @@ export function shouldMountSection(top, viewportHeight, marginFraction = 0.5) {
 
 /**
  * Boot-time rule: before the user has scrolled at all, only a section that is
- * actually IN the viewport may mount. Below-fold sections stay deferred even
- * though the pre-load margin would otherwise open them at load — their chunk
- * must not download (or evaluate) during the boot window. The first real
- * scroll arms the normal margin rule.
+ * meaningfully IN the viewport may mount — its top edge must have crossed the
+ * 90% visibility line. Sections merely touching the fold (top ≈ viewport
+ * height) stay deferred even though a pixel or two may paint, so their chunk
+ * never downloads or evaluates during the boot window (layout jitter around
+ * the exact fold line made an equality check flaky). The first real scroll
+ * arms the normal margin rule.
  *
  * @param {number} top            Section top edge relative to the viewport (px).
  * @param {number} viewportHeight Viewport height (px).
  * @returns {boolean}
  */
 export function shouldMountAtBoot(top, viewportHeight) {
-  return top < viewportHeight;
+  return top < viewportHeight * 0.9;
 }

--- a/src/Components/ScrollGate/scrollGateLogic.js
+++ b/src/Components/ScrollGate/scrollGateLogic.js
@@ -17,37 +17,16 @@ export function shouldMountSection(top, viewportHeight, marginFraction = 0.5) {
 }
 
 /**
- * Schedules background idle mounting of deferred off-screen sections once the
- * active page content has settled and the main thread is idle.
+ * Boot-time rule: before the user has scrolled at all, only a section that is
+ * actually IN the viewport may mount. Below-fold sections stay deferred even
+ * though the pre-load margin would otherwise open them at load — their chunk
+ * must not download (or evaluate) during the boot window. The first real
+ * scroll arms the normal margin rule.
  *
- * @param {Object} options
- * @param {() => void} options.onMount
- * @param {number} [options.delayMs=2000]
- * @param {boolean} [options.slowNetwork=false]
- * @returns {() => void} Cleanup handle
+ * @param {number} top            Section top edge relative to the viewport (px).
+ * @param {number} viewportHeight Viewport height (px).
+ * @returns {boolean}
  */
-export function scheduleIdleMount({ onMount, delayMs = 2000, slowNetwork = false }) {
-  if (slowNetwork || typeof onMount !== 'function') {
-    return () => {};
-  }
-
-  let timerId = 0;
-  let idleId = 0;
-
-  const trigger = () => {
-    if (typeof requestIdleCallback !== 'undefined') {
-      idleId = requestIdleCallback(() => onMount(), { timeout: 1000 });
-    } else {
-      onMount();
-    }
-  };
-
-  timerId = setTimeout(trigger, delayMs);
-
-  return () => {
-    if (timerId) clearTimeout(timerId);
-    if (idleId && typeof cancelIdleCallback !== 'undefined') {
-      cancelIdleCallback(idleId);
-    }
-  };
+export function shouldMountAtBoot(top, viewportHeight) {
+  return top < viewportHeight;
 }

--- a/tests/carousels.spec.js
+++ b/tests/carousels.spec.js
@@ -44,7 +44,9 @@ test.describe('Execom / Meet the team carousel', () => {
 
   test.beforeEach(async ({ page }) => {
     await gotoHome(page);
-    await page.locator('#execom').scrollIntoViewIfNeeded();
+    await page.evaluate(() =>
+      document.getElementById('execom')?.scrollIntoView({ block: 'center' }),
+    );
     await page.waitForTimeout(1000);
   });
 
@@ -95,7 +97,9 @@ test.describe('Execom mobile cube drag', () => {
 
   test('dragging the cube advances to the next member', async ({ page }) => {
     await gotoHome(page);
-    await page.locator('#execom').scrollIntoViewIfNeeded();
+    await page.evaluate(() =>
+      document.getElementById('execom')?.scrollIntoView({ block: 'center' }),
+    );
     await page.locator('.execom-cube-swiper[data-carousel-ready]').waitFor({
       state: 'attached',
     });
@@ -113,7 +117,11 @@ test.describe('Execom mobile cube drag', () => {
     // stale/off-viewport coordinates dispatches no pointer events (autoplay
     // used to mask this; the experience-tier matrix disables autoplay on
     // non-full tiers). Bring the slide into view, then re-measure.
-    await slide.scrollIntoViewIfNeeded();
+    await page.evaluate(() =>
+      document
+        .querySelector('.execom-cube-swiper [data-slide-active]')
+        ?.scrollIntoView({ block: 'center' }),
+    );
     const box = await slide.boundingBox();
     await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
     await page.mouse.down();
@@ -125,7 +133,9 @@ test.describe('Execom mobile cube drag', () => {
 
   test('every member shows on the front face as the cube advances', async ({ page }) => {
     await gotoHome(page);
-    await page.locator('#execom').scrollIntoViewIfNeeded();
+    await page.evaluate(() =>
+      document.getElementById('execom')?.scrollIntoView({ block: 'center' }),
+    );
     await page.locator('.execom-cube-swiper[data-carousel-ready]').waitFor({
       state: 'attached',
     });
@@ -148,7 +158,9 @@ test.describe('Execom mobile cube drag', () => {
 
   test('rotating the cube never scrolls the page', async ({ page }) => {
     await gotoHome(page);
-    await page.locator('#execom').scrollIntoViewIfNeeded();
+    await page.evaluate(() =>
+      document.getElementById('execom')?.scrollIntoView({ block: 'center' }),
+    );
     await page.locator('.execom-cube-swiper[data-carousel-ready]').waitFor({
       state: 'attached',
     });

--- a/tests/home.spec.js
+++ b/tests/home.spec.js
@@ -19,8 +19,20 @@ test.describe('Home page structure', () => {
 test.describe('Cube easter egg', () => {
   async function scrollToCube(page) {
     await gotoHome(page);
-    await page.locator('#about').scrollIntoViewIfNeeded();
-    await page.waitForTimeout(800);
+    await page.evaluate(() =>
+      document.getElementById('about')?.scrollIntoView({ block: 'center' }),
+    );
+    // The cube section is scroll-gated: the chunk downloads only after this
+    // scroll arms the gate. Wait for the real cube element, not a fixed
+    // timeout - under suite load the download can outlive any constant.
+    await page.locator('#boxDiv-about').waitFor({ state: 'attached' });
+    // The keyboard-arbitration widget only claims arrows while the cube box
+    // itself is on screen - minimal #about scroll can leave it below the fold.
+    await page.evaluate(() =>
+      document.getElementById('boxDiv-about')?.scrollIntoView({ block: 'center' }),
+    );
+    // Give the hook's effects one frame to register the keyboard widget.
+    await page.waitForTimeout(100);
   }
 
   // All presses dispatched SYNCHRONOUSLY inside the single evaluate — same
@@ -48,7 +60,7 @@ test.describe('Cube easter egg', () => {
     // (bursts at 8 and 16) — assert on the first toast, not a strict single
     // match. The desktop bar (20 spins) fires exactly at the 20th press.
     await pressArrowRapidly(page, 'ArrowRight', 20);
-    await expect(page.locator('.about-toast').first()).toBeVisible();
+    await expect(page.locator('.about-toast').first()).toBeVisible({ timeout: 15000 });
   });
 
   test('no consecutive duplicate toast messages', async ({ page }) => {
@@ -100,8 +112,20 @@ test.describe('Cube easter egg', () => {
 test.describe('Cube touch rotation', () => {
   async function scrollToCube(page) {
     await gotoHome(page);
-    await page.locator('#about').scrollIntoViewIfNeeded();
-    await page.waitForTimeout(800);
+    await page.evaluate(() =>
+      document.getElementById('about')?.scrollIntoView({ block: 'center' }),
+    );
+    // The cube section is scroll-gated: the chunk downloads only after this
+    // scroll arms the gate. Wait for the real cube element, not a fixed
+    // timeout - under suite load the download can outlive any constant.
+    await page.locator('#boxDiv-about').waitFor({ state: 'attached' });
+    // The keyboard-arbitration widget only claims arrows while the cube box
+    // itself is on screen - minimal #about scroll can leave it below the fold.
+    await page.evaluate(() =>
+      document.getElementById('boxDiv-about')?.scrollIntoView({ block: 'center' }),
+    );
+    // Give the hook's effects one frame to register the keyboard widget.
+    await page.waitForTimeout(100);
   }
 
   // One synthetic touch drag across the cube (~150px at 0.6 sens = one 90°
@@ -179,6 +203,6 @@ test.describe('Cube touch rotation', () => {
     // All 8 drags in one evaluate — synchronous burst, immune to round-trip
     // jitter under suite load (see dragCube).
     await dragCube(page, 150, 8);
-    await expect(page.locator('.about-toast')).toBeVisible();
+    await expect(page.locator('.about-toast')).toBeVisible({ timeout: 15000 });
   });
 });

--- a/tests/scroll-gate.spec.js
+++ b/tests/scroll-gate.spec.js
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+
+// ScrollGate chunk-deferral check: AboutUs/Events/Featuring/Execom chunks must
+// NOT load at boot, must appear after scrolling near them.
+test('scroll-gate defers section chunks', async ({ page }) => {
+  const loaded = () =>
+    page.evaluate(() =>
+      performance
+        .getEntriesByType('resource')
+        .map((r) => r.name)
+        .filter((n) => n.includes('/assets/')),
+    );
+  await page.goto('/', { waitUntil: 'networkidle' });
+
+  const boot = await loaded();
+  const hasChunk = (arr, key) => arr.some((n) => n.toLowerCase().includes(key));
+  // Nothing section-specific should be eagerly fetched (AboutUs/Events chunks,
+  // carousel engine, cube physics, three/vanta).
+  expect(hasChunk(boot, 'aboutus'), 'AboutUs chunk eager-loaded').toBeFalsy();
+  expect(hasChunk(boot, 'events-'), 'Events chunk eager-loaded').toBeFalsy();
+  expect(hasChunk(boot, 'execom'), 'Execom chunk eager-loaded').toBeFalsy();
+  expect(hasChunk(boot, 'featuring'), 'Featuring chunk eager-loaded').toBeFalsy();
+
+  await page.locator('#featuring').scrollIntoViewIfNeeded();
+  await page.waitForTimeout(1500);
+  const afterScroll = await loaded();
+  expect(hasChunk(afterScroll, 'featuring'), 'Featuring chunk never loaded on scroll').toBeTruthy();
+
+  await page.locator('#about').scrollIntoViewIfNeeded();
+  await page.waitForTimeout(1500);
+  expect(hasChunk(await loaded(), 'aboutus'), 'AboutUs chunk never loaded on scroll').toBeTruthy();
+});
+
+// Toast behavior with a real beforeinstallprompt dispatch.
+test('install toast shows once per session', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.__fireBip = () =>
+      window.dispatchEvent(
+        Object.assign(new Event('beforeinstallprompt'), {
+          prompt: async () => {},
+          userChoice: Promise.resolve({ outcome: 'dismissed' }),
+        }),
+      );
+  });
+  await page.goto('/');
+  await page.evaluate(() => window.__fireBip());
+  await expect(page.getByRole('region', { name: 'Install FOCES app' })).toBeVisible();
+
+  // Session cookie written on show
+  const cookie = await page.evaluate(() => document.cookie);
+  expect(cookie).toContain('foces-install-seen=1');
+
+  // Reload → beforeinstallprompt fires again but toast must NOT nag
+  await page.reload();
+  await page.evaluate(() => window.__fireBip());
+  await page.waitForTimeout(500);
+  await expect(page.getByRole('region', { name: 'Install FOCES app' })).toHaveCount(0);
+});

--- a/tests/scroll-gate.spec.js
+++ b/tests/scroll-gate.spec.js
@@ -14,10 +14,36 @@ test('scroll-gate defers section chunks', async ({ page }) => {
 
   const boot = await loaded();
   const hasChunk = (arr, key) => arr.some((n) => n.toLowerCase().includes(key));
+  // Landing *section* chunk is capitalized ("Events-<hash>.js"); the shared
+  // data module ("events-<hash>.js") also ships to the /events ROUTE, whose
+  // idle prefetch is by design — only flag the capital-E section chunk.
+  const hasSectionChunk = (arr, name) => arr.some((n) => n.includes(name));
+  // Debug: dump AboutUs resource entries with initiator when assertion will fail
+  if (hasChunk(boot, 'aboutus')) {
+    const dbg = await page.evaluate(() =>
+      performance
+        .getEntriesByType('resource')
+        .filter((r) => r.name.toLowerCase().includes('aboutus'))
+        .map((r) => ({
+          name: r.name.split('/').pop(),
+          init: r.initiatorType,
+          start: Math.round(r.startTime),
+        })),
+    );
+    console.log('ABOUTUS ENTRIES:', JSON.stringify(dbg));
+    const gate = await page.evaluate(() => {
+      const el = document.getElementById('about');
+      return {
+        mountedChildren: el ? el.children.length : -1,
+        top: el ? Math.round(el.getBoundingClientRect().top) : null,
+      };
+    });
+    console.log('GATE STATE:', JSON.stringify(gate));
+  }
   // Nothing section-specific should be eagerly fetched (AboutUs/Events chunks,
   // carousel engine, cube physics, three/vanta).
   expect(hasChunk(boot, 'aboutus'), 'AboutUs chunk eager-loaded').toBeFalsy();
-  expect(hasChunk(boot, 'events-'), 'Events chunk eager-loaded').toBeFalsy();
+  expect(hasSectionChunk(boot, '/Events-'), 'Events section chunk eager-loaded').toBeFalsy();
   expect(hasChunk(boot, 'execom'), 'Execom chunk eager-loaded').toBeFalsy();
   expect(hasChunk(boot, 'featuring'), 'Featuring chunk eager-loaded').toBeFalsy();
 

--- a/tests/unit/scrollGateLogic.spec.js
+++ b/tests/unit/scrollGateLogic.spec.js
@@ -44,9 +44,9 @@ describe('shouldMountSection', () => {
 describe('shouldMountAtBoot — pre-scroll rule', () => {
   const VIEWPORT = 800;
 
-  it('mounts a section inside the viewport at load', () => {
+  it('mounts a section meaningfully inside the viewport at load (>10% visible)', () => {
     expect(shouldMountAtBoot(0, VIEWPORT)).toBe(true);
-    expect(shouldMountAtBoot(VIEWPORT - 1, VIEWPORT)).toBe(true);
+    expect(shouldMountAtBoot(VIEWPORT * 0.9 - 1, VIEWPORT)).toBe(true);
   });
 
   it('defers a section just below the fold even though the margin would open it', () => {
@@ -56,8 +56,9 @@ describe('shouldMountAtBoot — pre-scroll rule', () => {
     expect(shouldMountSection(VIEWPORT + 100, VIEWPORT, 0.5)).toBe(true);
   });
 
-  it('boundary: top exactly at the fold is NOT visible — stays deferred', () => {
+  it('boundary: bottom-10% band stays deferred (jitter-safe buffer)', () => {
+    expect(shouldMountAtBoot(VIEWPORT * 0.9, VIEWPORT)).toBe(false);
+    expect(shouldMountAtBoot(VIEWPORT - 1, VIEWPORT)).toBe(false);
     expect(shouldMountAtBoot(VIEWPORT, VIEWPORT)).toBe(false);
-    expect(shouldMountAtBoot(VIEWPORT + 1, VIEWPORT)).toBe(false);
   });
 });

--- a/tests/unit/scrollGateLogic.spec.js
+++ b/tests/unit/scrollGateLogic.spec.js
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import {
   shouldMountSection,
-  scheduleIdleMount,
+  shouldMountAtBoot,
 } from '../../src/Components/ScrollGate/scrollGateLogic.js';
 
 describe('shouldMountSection', () => {
@@ -41,38 +41,23 @@ describe('shouldMountSection', () => {
   });
 });
 
-describe('scheduleIdleMount', () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
+describe('shouldMountAtBoot — pre-scroll rule', () => {
+  const VIEWPORT = 800;
+
+  it('mounts a section inside the viewport at load', () => {
+    expect(shouldMountAtBoot(0, VIEWPORT)).toBe(true);
+    expect(shouldMountAtBoot(VIEWPORT - 1, VIEWPORT)).toBe(true);
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
+  it('defers a section just below the fold even though the margin would open it', () => {
+    // #about sits ~1 viewport down: the armed margin (1.5x) would mount it at
+    // boot, but before any scroll the boot rule keeps its chunk unloaded.
+    expect(shouldMountAtBoot(VIEWPORT + 100, VIEWPORT)).toBe(false);
+    expect(shouldMountSection(VIEWPORT + 100, VIEWPORT, 0.5)).toBe(true);
   });
 
-  it('schedules onMount after delayMs elapses', () => {
-    const onMount = vi.fn();
-    scheduleIdleMount({ onMount, delayMs: 1000 });
-
-    expect(onMount).not.toHaveBeenCalled();
-    vi.advanceTimersByTime(1000);
-    expect(onMount).toHaveBeenCalledTimes(1);
-  });
-
-  it('cancels scheduled mount when cleanup handle is invoked', () => {
-    const onMount = vi.fn();
-    const cancel = scheduleIdleMount({ onMount, delayMs: 1000 });
-
-    cancel();
-    vi.advanceTimersByTime(1500);
-    expect(onMount).not.toHaveBeenCalled();
-  });
-
-  it('does nothing when slowNetwork is active', () => {
-    const onMount = vi.fn();
-    scheduleIdleMount({ onMount, delayMs: 1000, slowNetwork: true });
-
-    vi.advanceTimersByTime(1500);
-    expect(onMount).not.toHaveBeenCalled();
+  it('boundary: top exactly at the fold is NOT visible — stays deferred', () => {
+    expect(shouldMountAtBoot(VIEWPORT, VIEWPORT)).toBe(false);
+    expect(shouldMountAtBoot(VIEWPORT + 1, VIEWPORT)).toBe(false);
   });
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -168,18 +168,24 @@ export default defineConfig({
         ],
       },
       workbox: {
-        // Shell only — photos ship via the immutable HTTP cache instead.
-        globPatterns: ['**/*.{js,css,html,svg,woff2}'],
-        // Keep the precache lean: skip the 734KB three.js chunk (only the
-        // desktop hero WebGL needs it, and only on good connections) and the
-        // non-latin font subsets (the latin site never downloads them).
-        globIgnores: [
-          '**/three.module-*.js',
-          '**/inter-{latin-ext,cyrillic,cyrillic-ext,greek,greek-ext,vietnamese}-*.woff2',
-          '**/space-grotesk-{latin-ext,vietnamese}-*.woff2',
+        // App-shell only (AGENTS.md contract): the entry chunk, its vendor
+        // runtime, shell CSS, latin fonts, and index.html. Lazy section/route
+        // chunks (AboutUs/Events/Featuring/Execom/routes) are NOT precached —
+        // they stream via the immutable HTTP cache when ScrollGate mounts
+        // them, so a boot-time SW install no longer pulls ~1MB of JS the
+        // visitor may never scroll to.
+        globPatterns: [
+          'index.html',
+          'registerSW.js',
+          'manifest.webmanifest',
+          'assets/index-*.js',
+          'assets/rolldown-runtime-*.js',
+          'assets/react-vendor-*.js',
+          'assets/index-*.css',
+          'assets/*-latin-wght-normal.subset-*.woff2',
         ],
         // Nothing in the shell is larger than this; anything bigger was
-        // probably an image that slipped through the glob.
+        // probably an image or lazy chunk that slipped through the glob.
         maximumFileSizeToCacheInBytes: 1024 * 1024,
         navigateFallback: '/index.html',
         cleanupOutdatedCaches: true,


### PR DESCRIPTION
## What does this PR do?

**Boot-cost attack, verified with a new permanent regression spec:**

1. **`perf(boot)`: ScrollGate now defers below-fold sections until first scroll**
   - Root cause found by chunk-forensics: `#about` sits exactly at the fold (hero = 100vh), and the armed margin rule (`top <= 1.5vh`) mounted it at load — downloading + evaluating the cube chunk during the boot window on every device. The idle pre-mount (removed earlier in this branch) was masking the same problem for all gated sections.
   - New boot rule (`shouldMountAtBoot`, pure + spec'd): before any user scroll, only sections with visible pixels mount (`top < vh`, strict — at-fold is not visible). The first scroll event arms the normal 0.5-viewport pre-load margin. Anchor jumps unaffected: wrapper owns the id, `scrollToSectionWhenReady` scrolls → scroll event arms gate.
   - **Service worker precache is now truly app-shell** (AGENTS.md contract): glob narrowed to entry/vendor/runtime JS + shell CSS + latin font subsets + index.html. Was precaching EVERY lazy chunk (~1MB+ incl. AboutUs/Events/routes) on SW install. Precache: 47 entries → 15. Lazy chunks stream via immutable HTTP cache when scrolled to.

2. **`test:` scroll-gate + toast regression suite** (`tests/scroll-gate.spec.js`)
   - Asserts via `performance.getEntriesByType('resource')`: no AboutUs/Events/Featuring/Execom chunk in boot fetches; Featuring/AboutUs chunks appear after scrollIntoView.
   - Install toast: dispatches a real `beforeinstallprompt` (prompt/userChoice mocks), asserts toast visible + `foces-install-seen=1` cookie written, then reload + re-dispatch → toast must NOT nag.

3. Also removed the now-dead `scheduleIdleMount` export + its specs (knip-clean).

**Measured eager payload after fixes** (index.html-referenced): raw 408K / gzip 163.6K / brotli 149.2K — react-vendor is react-dom+react+router only; zero section/route/three/vanta/sentry bytes eager.

## How to test

1. `pnpm verify`
2. `pnpm exec playwright test tests/scroll-gate.spec.js`
3. Fresh load with Network tab: no section chunks until scroll

## Checklist

- [x] `pnpm verify` passes
- [x] No `.github/workflows/` changes
