### PR TITLE
build: scope sonarcloud analysis to src and fix binding keys

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,13 @@
-sonar.projectKey=foces_core_official_website_v3
-sonar.organization=sebin-gg
-sonar.sources=.
-sonar.language=js
-sonar.python.version=3
-sonar.qualitygate.wait=false
+# SonarCloud configuration (automatic analysis reads this from main).
+# Binding comes from the SonarCloud GitHub App; the identity keys below must
+# match it if CI-based scanning is ever added.
+sonar.projectKey=Foces-core_Official_website_v3
+sonar.organization=Foces-core
+
+# Only analyze first-party app code — foces-webv23/ is the archived Sanity
+# studio (see AGENTS.md: off-limits) and its legacy deps must never pollute
+# the quality gate.
+sonar.sources=src
+sonar.tests=tests
+sonar.test.inclusions=**/*.spec.js,**/*.test.js,**/*.spec.jsx,**/*.test.jsx
+sonar.exclusions=foces-webv23/**,dist/**,coverage/**,node_modules/**


### PR DESCRIPTION
## Why SonarCloud's check is red
Automatic analysis **is** running (8 analyses today) but the Quality Gate fails on one condition: \
ew_security_rating\ = C (needs A). Root cause in the old config:

- \sonar.sources=.\ → scanned the entire repo, including the archived \oces-webv23/\ Sanity studio that every other tool in this repo deliberately ignores (AGENTS.md: off-limits) — its legacy code/deps drive the vulnerability count.
- \sonar.projectKey\ / \sonar.organization\ didn't match the real SonarCloud project (\Foces-core_Official_website_v3\ / org \Foces-core\) — verified via the public API.
- Removed dead params (\sonar.language\, \sonar.python.version=3\).

## Change
Scopes analysis to \src/\ (+ \	ests/\ as test sources), excludes \oces-webv23/\, \dist/\, \coverage/\, \
ode_modules/\.

## Post-merge expectation
Next push to main re-analyzes; if \src/\ is clean of vulnerability findings, \
ew_security_rating\ returns to A and the PR check goes green.