### PR TITLE
ci: switch harden-runner to block egress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,21 @@ jobs:
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2
         with:
           egress-policy: block
+          # Explicit allowlist for block mode — everything a JS/pnpm/Playwright
+          # CI job legitimately needs. The trailing-dot registry.npmjs.org.
+          # entry covers the absolute-FQDN form resolvers hand back (seen in
+          # StepSecurity block notifications). Extend only with justification.
+          allowed-endpoints: >
+            registry.npmjs.org:443
+            registry.npmjs.org.:443
+            nodejs.org:443
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            cdn.playwright.dev:443
+            playwright.azureedge.net:443
+            playwright.download.prss.microsoft.com:443
 
       - name: Install pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
@@ -103,6 +118,21 @@ jobs:
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2
         with:
           egress-policy: block
+          # Explicit allowlist for block mode — everything a JS/pnpm/Playwright
+          # CI job legitimately needs. The trailing-dot registry.npmjs.org.
+          # entry covers the absolute-FQDN form resolvers hand back (seen in
+          # StepSecurity block notifications). Extend only with justification.
+          allowed-endpoints: >
+            registry.npmjs.org:443
+            registry.npmjs.org.:443
+            nodejs.org:443
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            cdn.playwright.dev:443
+            playwright.azureedge.net:443
+            playwright.download.prss.microsoft.com:443
 
       - name: Install pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
@@ -144,6 +174,21 @@ jobs:
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2
         with:
           egress-policy: block
+          # Explicit allowlist for block mode — everything a JS/pnpm/Playwright
+          # CI job legitimately needs. The trailing-dot registry.npmjs.org.
+          # entry covers the absolute-FQDN form resolvers hand back (seen in
+          # StepSecurity block notifications). Extend only with justification.
+          allowed-endpoints: >
+            registry.npmjs.org:443
+            registry.npmjs.org.:443
+            nodejs.org:443
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            cdn.playwright.dev:443
+            playwright.azureedge.net:443
+            playwright.download.prss.microsoft.com:443
 
       - name: Install pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
             cdn.playwright.dev:443
             playwright.azureedge.net:443
             playwright.download.prss.microsoft.com:443
+            storage.googleapis.com:443
 
       - name: Install pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
@@ -135,6 +136,7 @@ jobs:
             cdn.playwright.dev:443
             playwright.azureedge.net:443
             playwright.download.prss.microsoft.com:443
+            storage.googleapis.com:443
             azure.archive.ubuntu.com:80
             azure.archive.ubuntu.com:443
             security.ubuntu.com:80
@@ -199,6 +201,7 @@ jobs:
             cdn.playwright.dev:443
             playwright.azureedge.net:443
             playwright.download.prss.microsoft.com:443
+            storage.googleapis.com:443
             azure.archive.ubuntu.com:80
             azure.archive.ubuntu.com:443
             security.ubuntu.com:80

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2
         with:
-          egress-policy: audit
+          egress-policy: block
 
       - name: Install pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
@@ -102,7 +102,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2
         with:
-          egress-policy: audit
+          egress-policy: block
 
       - name: Install pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
@@ -143,7 +143,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2
         with:
-          egress-policy: audit
+          egress-policy: block
 
       - name: Install pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,9 @@ jobs:
           # Explicit allowlist for block mode — everything a JS/pnpm/Playwright
           # CI job legitimately needs. The trailing-dot registry.npmjs.org.
           # entry covers the absolute-FQDN form resolvers hand back (seen in
-          # StepSecurity block notifications). Extend only with justification.
+          # StepSecurity block notifications). The OS/package-repo hosts below
+          # serve `playwright install --with-deps` system packages. Extend
+          # only with justification.
           allowed-endpoints: >
             registry.npmjs.org:443
             registry.npmjs.org.:443
@@ -133,6 +135,12 @@ jobs:
             cdn.playwright.dev:443
             playwright.azureedge.net:443
             playwright.download.prss.microsoft.com:443
+            azure.archive.ubuntu.com:80
+            azure.archive.ubuntu.com:443
+            security.ubuntu.com:80
+            security.ubuntu.com:443
+            packages.microsoft.com:443
+            dl.google.com:443
 
       - name: Install pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
@@ -177,7 +185,9 @@ jobs:
           # Explicit allowlist for block mode — everything a JS/pnpm/Playwright
           # CI job legitimately needs. The trailing-dot registry.npmjs.org.
           # entry covers the absolute-FQDN form resolvers hand back (seen in
-          # StepSecurity block notifications). Extend only with justification.
+          # StepSecurity block notifications). The OS/package-repo hosts below
+          # serve `playwright install --with-deps` system packages. Extend
+          # only with justification.
           allowed-endpoints: >
             registry.npmjs.org:443
             registry.npmjs.org.:443
@@ -189,6 +199,12 @@ jobs:
             cdn.playwright.dev:443
             playwright.azureedge.net:443
             playwright.download.prss.microsoft.com:443
+            azure.archive.ubuntu.com:80
+            azure.archive.ubuntu.com:443
+            security.ubuntu.com:80
+            security.ubuntu.com:443
+            packages.microsoft.com:443
+            dl.google.com:443
 
       - name: Install pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6


### PR DESCRIPTION
Flips StepSecurity Harden-Runner from audit to block mode in all three build/test jobs (Lint & Build, E2E, Probes) after a clean audit-log review — StepSecurity Threat Center reports 'Affecting You: 0' across all 50 tracked campaigns.

From now on, any compromised package attempting an outbound callback during CI gets its connection **blocked**, not just recorded. This also auto-enforces the StepSecurity global block list (covers active campaigns like Laravel-Lang exfil and the actions-cool tag-poison C2).

Note: if a legitimate dependency ever needs a new outbound host, CI will fail with a Harden-Runner violation — add it to the allow list in that job's step.