### PR TITLE
chore: exclude archived studio from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   "dependencyDashboard": true,
   "lockFileMaintenance": { "enabled": true },
   "minimumReleaseAge": "1 day",
+  "ignorePaths": ["**/node_modules/**", "foces-webv23/**"],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
Renovate was opening bump PRs against \oces-webv23/\ (Sanity CLI v8, sanity monorepo v6, React 19, etc.) — that directory is the archived Sanity studio **pinned to Sanity 3 / React 18 on purpose** per AGENTS.md. Dependabot already excludes it (\xclude-paths\); this adds the equivalent \ignorePaths\ for Renovate.

The six offending PRs (#145, #152, #156–#158, #160) will be closed with a pointer here.