### PR TITLE
ci: silence chromium background networking in browser tests

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -17,6 +17,19 @@ export default defineConfig({
     baseURL: BASE_URL,
     headless: true,
     trace: 'retain-on-failure',
+    // Kill Chromium's background phone-home (component updater →
+    // clients2.google.com, FCM → mtalk.google.com, Safe Browsing pings).
+    // Harmless read-only telemetry, but in block-mode CI every attempt trips
+    // a Harden-Runner alert, so tests run a fully quiet browser.
+    launchOptions: {
+      args: [
+        '--disable-background-networking',
+        '--disable-component-update',
+        '--disable-client-side-phishing-detection',
+        '--disable-sync',
+        '--no-pings',
+      ],
+    },
   },
   // Run E2E against the PRODUCTION build (vite build + vite preview), not the
   // dev server — catches minification, code-splitting, and asset-hash issues

--- a/scripts/probes/carousel-probe.mjs
+++ b/scripts/probes/carousel-probe.mjs
@@ -9,7 +9,14 @@ if (!chromePath) {
 const b = await puppeteer.launch({
   executablePath: chromePath,
   headless: 'new',
-  args: ['--no-sandbox'],
+  args: [
+    '--no-sandbox',
+    '--disable-background-networking',
+    '--disable-component-update',
+    '--disable-client-side-phishing-detection',
+    '--disable-sync',
+    '--no-pings',
+  ],
 });
 const out = [];
 

--- a/scripts/probes/mobile-probe.mjs
+++ b/scripts/probes/mobile-probe.mjs
@@ -10,7 +10,14 @@ if (!chromePath) {
 const b = await puppeteer.launch({
   executablePath: chromePath,
   headless: 'new',
-  args: ['--no-sandbox'],
+  args: [
+    '--no-sandbox',
+    '--disable-background-networking',
+    '--disable-component-update',
+    '--disable-client-side-phishing-detection',
+    '--disable-sync',
+    '--no-pings',
+  ],
 });
 
 // MOBILE /events page

--- a/scripts/probes/wcag-probe.mjs
+++ b/scripts/probes/wcag-probe.mjs
@@ -18,7 +18,15 @@ const check = (name, ok, detail = '') => {
 const browser = await puppeteer.launch({
   executablePath: chromePath,
   headless: 'new',
-  args: ['--no-sandbox', '--window-size=1280,800'],
+  args: [
+    '--no-sandbox',
+    '--window-size=1280,800',
+    '--disable-background-networking',
+    '--disable-component-update',
+    '--disable-client-side-phishing-detection',
+    '--disable-sync',
+    '--no-pings',
+  ],
 });
 
 try {


### PR DESCRIPTION
Follow-up to #162: instead of only allowlisting Chromium's phone-home endpoints, kill them at the source.

- \playwright.config.js\ — \launchOptions.args\ adds \--disable-background-networking\, \--disable-component-update\, \--disable-client-side-phishing-detection\, \--disable-sync\, \--no-pings\ (inherited by both chromium + mobile projects)
- \scripts/probes/{wcag,carousel,mobile}-probe.mjs\ — same flags for the puppeteer launches

Stops component-updater (\clients2.google.com\), FCM (\mtalk.google.com\) and Safe-Browsing pings from ever firing in CI, so the StepSecurity Harden-Runner check stays green without further allowlist churn. The google/vercel allowlist entries stay as belt-and-braces.