### PR TITLE
ci: add trailing-dot and mtalk variants to google allowlist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,10 +141,14 @@ jobs:
             # Vercel analytics script fire while tests drive a real browser.
             # Read-only telemetry from a disposable CI profile.
             clients2.google.com:443
+            clients2.google.com.:443
             www.google.com:443
             accounts.google.com:443
             update.googleapis.com:443
             android.clients.google.com:443
+            android.clients.google.com.:443
+            mtalk.google.com:443
+            mtalk.google.com.:443
             va.vercel-scripts.com:443
 
       - name: Install pnpm
@@ -210,10 +214,14 @@ jobs:
             # Vercel analytics script fire while tests drive a real browser.
             # Read-only telemetry from a disposable CI profile.
             clients2.google.com:443
+            clients2.google.com.:443
             www.google.com:443
             accounts.google.com:443
             update.googleapis.com:443
             android.clients.google.com:443
+            android.clients.google.com.:443
+            mtalk.google.com:443
+            mtalk.google.com.:443
             va.vercel-scripts.com:443
 
       - name: Install pnpm


### PR DESCRIPTION
Final piece for a green Harden-Runner check: the block report showed \clients2.google.com\ (DNS absolute-FQDN form, same trailing-dot issue as registry.npmjs.org) and \mtalk.google.com\ (FCM socket) still getting blocked. Adds both plus trailing-dot variants of the google entries.