### PR TITLE
chore(security): bump gitleaks rev for pre-commit users

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.18.4
+    rev: v8.24.3
     hooks:
       - id: gitleaks


### PR DESCRIPTION
## What does this PR do?

**Secret-scanning hardening, three layers (follow-up to the direct-to-main gitleaks commit `ecf692f`):**

1. **GitHub-native enforcement is ON** (repo settings, done outside this PR): secret scanning + push protection are enabled — recognized secrets are blocked at push time server-side, zero maintenance.
2. **`.pre-commit-config.yaml`**: bumped gitleaks rev v8.18.4 → v8.24.3 for contributors who opt into the pre-commit framework (`pip install pre-commit && pre-commit install`).
3. The husky pre-commit chain stays as-is (lint-staged only): there is no real gitleaks npm package (the registry's `gitleaks@1.0.0` is an unrelated squatter), so a local binary scan can't be wired through npx. The two layers above cover it: server-side block + opt-in local scan.

Note for maintainers: do NOT run `pre-commit install` in this repo — it would replace husky's hook path and silently disable lint-staged/commitlint.

## Checklist

- [x] Config-only change
- [x] No code changes
